### PR TITLE
Phase 4: Wizard Component and Draw Context Fix

### DIFF
--- a/frontend/src/features/Dashboard/components/DraftCard.tsx
+++ b/frontend/src/features/Dashboard/components/DraftCard.tsx
@@ -1,0 +1,272 @@
+/**
+ * Draft Card Component
+ *
+ * Displays a single draft model with actions.
+ */
+
+import React from 'react';
+import type { DraftSummary, DraftType } from '../types/draft';
+
+/**
+ * Props for DraftCard
+ */
+interface DraftCardProps {
+  /** Draft to display */
+  draft: DraftSummary;
+  /** Called when resume button is clicked */
+  onResume: (draftId: string) => void;
+  /** Called when delete button is clicked */
+  onDelete: (draftId: string) => void;
+  /** Whether the card is selected */
+  isSelected?: boolean;
+  /** Called when selection changes */
+  onSelect?: (draftId: string, selected: boolean) => void;
+}
+
+/**
+ * Get display name for draft type
+ */
+function getTypeName(type: DraftType): string {
+  switch (type) {
+    case 'model-setup':
+      return 'Fire Model';
+    case 'model-review':
+      return 'Model Review';
+    case 'model-export':
+      return 'Export';
+    default:
+      return 'Draft';
+  }
+}
+
+/**
+ * Get icon for draft type
+ */
+function getTypeIcon(type: DraftType): string {
+  switch (type) {
+    case 'model-setup':
+      return '🔥';
+    case 'model-review':
+      return '📊';
+    case 'model-export':
+      return '📤';
+    default:
+      return '📝';
+  }
+}
+
+/**
+ * Format relative time
+ */
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString();
+}
+
+/**
+ * DraftCard displays a draft model summary with actions.
+ */
+export function DraftCard({
+  draft,
+  onResume,
+  onDelete,
+  isSelected = false,
+  onSelect,
+}: DraftCardProps) {
+  const handleResume = () => onResume(draft.id);
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (window.confirm(`Delete "${draft.name}"? This cannot be undone.`)) {
+      onDelete(draft.id);
+    }
+  };
+  const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onSelect?.(draft.id, e.target.checked);
+  };
+
+  const cardStyle: React.CSSProperties = {
+    backgroundColor: 'white',
+    borderRadius: '8px',
+    border: isSelected ? '2px solid #1976d2' : '1px solid #e0e0e0',
+    padding: '16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+    boxShadow: isSelected ? '0 2px 8px rgba(25, 118, 210, 0.2)' : '0 1px 3px rgba(0,0,0,0.1)',
+  };
+
+  const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+  };
+
+  const titleSectionStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    flex: 1,
+  };
+
+  const iconStyle: React.CSSProperties = {
+    fontSize: '24px',
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '16px',
+    fontWeight: 600,
+    color: '#333',
+    margin: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  };
+
+  const typeTagStyle: React.CSSProperties = {
+    fontSize: '11px',
+    padding: '2px 8px',
+    borderRadius: '12px',
+    backgroundColor: '#e3f2fd',
+    color: '#1565c0',
+    fontWeight: 500,
+  };
+
+  const progressContainerStyle: React.CSSProperties = {
+    width: '100%',
+  };
+
+  const progressBarBgStyle: React.CSSProperties = {
+    height: '6px',
+    backgroundColor: '#e0e0e0',
+    borderRadius: '3px',
+    overflow: 'hidden',
+  };
+
+  const progressBarFillStyle: React.CSSProperties = {
+    height: '100%',
+    backgroundColor: draft.completionPercentage === 100 ? '#4caf50' : '#1976d2',
+    borderRadius: '3px',
+    width: `${draft.completionPercentage}%`,
+    transition: 'width 0.3s',
+  };
+
+  const progressTextStyle: React.CSSProperties = {
+    fontSize: '12px',
+    color: '#666',
+    marginTop: '4px',
+    display: 'flex',
+    justifyContent: 'space-between',
+  };
+
+  const metaStyle: React.CSSProperties = {
+    fontSize: '12px',
+    color: '#666',
+    display: 'flex',
+    gap: '16px',
+  };
+
+  const actionsStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: '8px',
+    marginTop: '4px',
+  };
+
+  const resumeButtonStyle: React.CSSProperties = {
+    flex: 1,
+    padding: '8px 16px',
+    backgroundColor: '#1976d2',
+    color: 'white',
+    border: 'none',
+    borderRadius: '4px',
+    fontSize: '14px',
+    fontWeight: 500,
+    cursor: 'pointer',
+  };
+
+  const deleteButtonStyle: React.CSSProperties = {
+    padding: '8px 12px',
+    backgroundColor: 'white',
+    color: '#d32f2f',
+    border: '1px solid #ffcdd2',
+    borderRadius: '4px',
+    fontSize: '14px',
+    cursor: 'pointer',
+  };
+
+  return (
+    <div
+      style={cardStyle}
+      onClick={handleResume}
+      role="article"
+      aria-label={`Draft: ${draft.name}`}
+    >
+      <div style={headerStyle}>
+        {onSelect && (
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={handleSelect}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Select ${draft.name}`}
+          />
+        )}
+        <div style={titleSectionStyle}>
+          <span style={iconStyle}>{getTypeIcon(draft.type)}</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <h3 style={titleStyle}>{draft.name}</h3>
+            {draft.description && (
+              <p style={{ ...metaStyle, marginTop: '4px', marginBottom: 0 }}>
+                {draft.description}
+              </p>
+            )}
+          </div>
+        </div>
+        <span style={typeTagStyle}>{getTypeName(draft.type)}</span>
+      </div>
+
+      <div style={progressContainerStyle}>
+        <div style={progressBarBgStyle}>
+          <div style={progressBarFillStyle} />
+        </div>
+        <div style={progressTextStyle}>
+          <span>Step {draft.currentStep + 1} of {draft.totalSteps}</span>
+          <span>{draft.completionPercentage}% complete</span>
+        </div>
+      </div>
+
+      <div style={metaStyle}>
+        <span>Modified {formatRelativeTime(draft.updatedAt)}</span>
+        <span>Created {formatRelativeTime(draft.createdAt)}</span>
+      </div>
+
+      <div style={actionsStyle}>
+        <button
+          style={resumeButtonStyle}
+          onClick={handleResume}
+        >
+          Continue
+        </button>
+        <button
+          style={deleteButtonStyle}
+          onClick={handleDelete}
+          aria-label={`Delete ${draft.name}`}
+        >
+          🗑️
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/Dashboard/components/DraftsDashboard.tsx
+++ b/frontend/src/features/Dashboard/components/DraftsDashboard.tsx
@@ -1,0 +1,352 @@
+/**
+ * Drafts Dashboard Component
+ *
+ * Displays all draft models with the ability to resume or delete.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { useDrafts } from '../hooks/useDrafts';
+import { DraftCard } from './DraftCard';
+import type { DraftType, DraftSortOption } from '../types/draft';
+
+/**
+ * Props for DraftsDashboard
+ */
+interface DraftsDashboardProps {
+  /** Called when user clicks resume on a draft */
+  onResume: (draftId: string) => void;
+  /** Called when user wants to create a new model */
+  onCreateNew?: () => void;
+  /** CSS class */
+  className?: string;
+}
+
+/**
+ * DraftsDashboard shows all saved draft models.
+ *
+ * @example
+ * ```tsx
+ * <DraftsDashboard
+ *   onResume={(id) => navigate(`/wizard/${id}`)}
+ *   onCreateNew={() => navigate('/wizard/new')}
+ * />
+ * ```
+ */
+export function DraftsDashboard({
+  onResume,
+  onCreateNew,
+  className = '',
+}: DraftsDashboardProps) {
+  const {
+    drafts,
+    isLoading,
+    isEmpty,
+    sortBy,
+    sortDirection,
+    filters,
+    setFilters,
+    toggleSort,
+    deleteDraft,
+    deleteDrafts,
+    refresh,
+  } = useDrafts({ refreshInterval: 30000 });
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const handleSelect = useCallback((id: string, selected: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (selected) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSelectAll = useCallback(() => {
+    if (selectedIds.size === drafts.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(drafts.map((d) => d.id)));
+    }
+  }, [drafts, selectedIds.size]);
+
+  const handleDeleteSelected = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    if (window.confirm(`Delete ${selectedIds.size} draft(s)? This cannot be undone.`)) {
+      deleteDrafts(Array.from(selectedIds));
+      setSelectedIds(new Set());
+    }
+  }, [selectedIds, deleteDrafts]);
+
+  const handleTypeFilter = useCallback((type: DraftType | '') => {
+    setFilters((prev) => ({
+      ...prev,
+      type: type === '' ? undefined : type,
+    }));
+  }, [setFilters]);
+
+  const handleSearch = useCallback((search: string) => {
+    setFilters((prev) => ({
+      ...prev,
+      search: search || undefined,
+    }));
+  }, [setFilters]);
+
+  const containerStyle: React.CSSProperties = {
+    padding: '24px',
+    maxWidth: '1200px',
+    margin: '0 auto',
+  };
+
+  const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: '24px',
+    flexWrap: 'wrap',
+    gap: '16px',
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '28px',
+    fontWeight: 600,
+    color: '#333',
+    margin: 0,
+  };
+
+  const actionsStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: '12px',
+    flexWrap: 'wrap',
+  };
+
+  const toolbarStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: '16px',
+    padding: '12px',
+    backgroundColor: '#f5f5f5',
+    borderRadius: '8px',
+    flexWrap: 'wrap',
+    gap: '12px',
+  };
+
+  const filterGroupStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+    flexWrap: 'wrap',
+  };
+
+  const selectStyle: React.CSSProperties = {
+    padding: '8px 12px',
+    borderRadius: '4px',
+    border: '1px solid #ccc',
+    fontSize: '14px',
+    backgroundColor: 'white',
+  };
+
+  const inputStyle: React.CSSProperties = {
+    padding: '8px 12px',
+    borderRadius: '4px',
+    border: '1px solid #ccc',
+    fontSize: '14px',
+    width: '200px',
+  };
+
+  const buttonStyle: React.CSSProperties = {
+    padding: '10px 20px',
+    borderRadius: '4px',
+    border: 'none',
+    fontSize: '14px',
+    fontWeight: 500,
+    cursor: 'pointer',
+  };
+
+  const primaryButtonStyle: React.CSSProperties = {
+    ...buttonStyle,
+    backgroundColor: '#1976d2',
+    color: 'white',
+  };
+
+  const secondaryButtonStyle: React.CSSProperties = {
+    ...buttonStyle,
+    backgroundColor: 'white',
+    color: '#333',
+    border: '1px solid #ccc',
+  };
+
+  const dangerButtonStyle: React.CSSProperties = {
+    ...buttonStyle,
+    backgroundColor: 'white',
+    color: '#d32f2f',
+    border: '1px solid #ffcdd2',
+  };
+
+  const gridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+    gap: '16px',
+  };
+
+  const emptyStateStyle: React.CSSProperties = {
+    textAlign: 'center',
+    padding: '48px 24px',
+    backgroundColor: '#fafafa',
+    borderRadius: '8px',
+    border: '2px dashed #e0e0e0',
+  };
+
+  const emptyIconStyle: React.CSSProperties = {
+    fontSize: '48px',
+    marginBottom: '16px',
+  };
+
+  const emptyTitleStyle: React.CSSProperties = {
+    fontSize: '18px',
+    fontWeight: 600,
+    color: '#333',
+    marginBottom: '8px',
+  };
+
+  const emptyTextStyle: React.CSSProperties = {
+    fontSize: '14px',
+    color: '#666',
+    marginBottom: '24px',
+  };
+
+  const sortOptions: { value: DraftSortOption; label: string }[] = [
+    { value: 'updatedAt', label: 'Last Modified' },
+    { value: 'createdAt', label: 'Created' },
+    { value: 'name', label: 'Name' },
+    { value: 'completion', label: 'Completion' },
+  ];
+
+  const typeOptions: { value: DraftType | ''; label: string }[] = [
+    { value: '', label: 'All Types' },
+    { value: 'model-setup', label: 'Fire Models' },
+    { value: 'model-review', label: 'Reviews' },
+    { value: 'model-export', label: 'Exports' },
+  ];
+
+  if (isLoading) {
+    return (
+      <div style={containerStyle} className={className}>
+        <div style={{ textAlign: 'center', padding: '48px' }}>
+          <p>Loading drafts...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={containerStyle} className={`drafts-dashboard ${className}`}>
+      <div style={headerStyle}>
+        <h1 style={titleStyle}>Your Drafts</h1>
+        <div style={actionsStyle}>
+          <button
+            style={secondaryButtonStyle}
+            onClick={refresh}
+            title="Refresh"
+          >
+            🔄 Refresh
+          </button>
+          {onCreateNew && (
+            <button style={primaryButtonStyle} onClick={onCreateNew}>
+              + New Model
+            </button>
+          )}
+        </div>
+      </div>
+
+      {!isEmpty && (
+        <div style={toolbarStyle}>
+          <div style={filterGroupStyle}>
+            <input
+              type="checkbox"
+              checked={selectedIds.size > 0 && selectedIds.size === drafts.length}
+              onChange={handleSelectAll}
+              aria-label="Select all"
+            />
+            <span style={{ fontSize: '14px', color: '#666' }}>
+              {selectedIds.size > 0
+                ? `${selectedIds.size} selected`
+                : `${drafts.length} draft${drafts.length !== 1 ? 's' : ''}`}
+            </span>
+            {selectedIds.size > 0 && (
+              <button style={dangerButtonStyle} onClick={handleDeleteSelected}>
+                Delete Selected
+              </button>
+            )}
+          </div>
+
+          <div style={filterGroupStyle}>
+            <input
+              type="text"
+              placeholder="Search drafts..."
+              value={filters.search || ''}
+              onChange={(e) => handleSearch(e.target.value)}
+              style={inputStyle}
+            />
+            <select
+              value={filters.type || ''}
+              onChange={(e) => handleTypeFilter(e.target.value as DraftType | '')}
+              style={selectStyle}
+            >
+              {typeOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <select
+              value={sortBy}
+              onChange={(e) => toggleSort(e.target.value as DraftSortOption)}
+              style={selectStyle}
+            >
+              {sortOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label} {sortBy === opt.value ? (sortDirection === 'desc' ? '↓' : '↑') : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {isEmpty ? (
+        <div style={emptyStateStyle}>
+          <div style={emptyIconStyle}>📝</div>
+          <h2 style={emptyTitleStyle}>No Drafts Yet</h2>
+          <p style={emptyTextStyle}>
+            Your in-progress fire models will appear here.
+            <br />
+            Start a new model to get started.
+          </p>
+          {onCreateNew && (
+            <button style={primaryButtonStyle} onClick={onCreateNew}>
+              + Create New Model
+            </button>
+          )}
+        </div>
+      ) : (
+        <div style={gridStyle}>
+          {drafts.map((draft) => (
+            <DraftCard
+              key={draft.id}
+              draft={draft}
+              onResume={onResume}
+              onDelete={deleteDraft}
+              isSelected={selectedIds.has(draft.id)}
+              onSelect={handleSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/Dashboard/hooks/useDrafts.ts
+++ b/frontend/src/features/Dashboard/hooks/useDrafts.ts
@@ -1,0 +1,265 @@
+/**
+ * Drafts Hook
+ *
+ * Manages draft models from localStorage.
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import {
+  getItemsByPrefix,
+  removeItem,
+  getRawItem,
+} from '../../../shared/utils/storage';
+import type { DraftSummary, DraftType, DraftSortOption, DraftFilterOptions } from '../types/draft';
+
+/**
+ * Storage key prefix for wizard drafts
+ */
+const DRAFT_KEY_PREFIX = 'nomad_wizard_draft_';
+
+/**
+ * Default TTL for drafts (30 days)
+ */
+const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Extract draft summary from stored wizard state
+ */
+function extractDraftSummary(key: string, data: unknown): DraftSummary | null {
+  if (!data || typeof data !== 'object') return null;
+
+  const state = data as Record<string, unknown>;
+  const draftId = (state.draftId as string) || key.replace(DRAFT_KEY_PREFIX, '');
+  const steps = (state.steps as unknown[]) || [];
+  const currentStep = (state.currentStepIndex as number) ?? 0;
+  const totalSteps = steps.length || 1;
+  const createdAt = (state.createdAt as number) || Date.now();
+  const updatedAt = (state.updatedAt as number) || Date.now();
+
+  // Calculate completion percentage
+  const visitedSteps = steps.filter((s: unknown) =>
+    s && typeof s === 'object' && (s as Record<string, unknown>).visited
+  ).length;
+  const completionPercentage = Math.round((visitedSteps / totalSteps) * 100);
+
+  // Determine draft type from data or steps
+  const draftData = state.data as Record<string, unknown> | undefined;
+  let type: DraftType = 'unknown';
+  let name = 'Untitled Draft';
+  let description: string | undefined;
+
+  if (draftData) {
+    // Try to determine type from workflow field
+    const workflow = draftData.workflow as string;
+    if (workflow === 'model-setup' || workflow === 'setup') {
+      type = 'model-setup';
+      name = (draftData.modelName as string) || 'Fire Model';
+      description = draftData.description as string;
+    } else if (workflow === 'review') {
+      type = 'model-review';
+      name = (draftData.modelName as string) || 'Model Review';
+    } else if (workflow === 'export') {
+      type = 'model-export';
+      name = (draftData.modelName as string) || 'Model Export';
+    } else if (draftData.modelName) {
+      type = 'model-setup';
+      name = draftData.modelName as string;
+    }
+  }
+
+  return {
+    id: draftId,
+    name,
+    type,
+    currentStep,
+    totalSteps,
+    completionPercentage,
+    createdAt: new Date(createdAt),
+    updatedAt: new Date(updatedAt),
+    description,
+  };
+}
+
+/**
+ * Sort drafts by field
+ */
+function sortDrafts(
+  drafts: DraftSummary[],
+  sortBy: DraftSortOption,
+  direction: 'asc' | 'desc'
+): DraftSummary[] {
+  const sorted = [...drafts].sort((a, b) => {
+    let comparison = 0;
+
+    switch (sortBy) {
+      case 'updatedAt':
+        comparison = a.updatedAt.getTime() - b.updatedAt.getTime();
+        break;
+      case 'createdAt':
+        comparison = a.createdAt.getTime() - b.createdAt.getTime();
+        break;
+      case 'name':
+        comparison = a.name.localeCompare(b.name);
+        break;
+      case 'completion':
+        comparison = a.completionPercentage - b.completionPercentage;
+        break;
+    }
+
+    return direction === 'desc' ? -comparison : comparison;
+  });
+
+  return sorted;
+}
+
+/**
+ * Filter drafts
+ */
+function filterDrafts(
+  drafts: DraftSummary[],
+  filters: DraftFilterOptions
+): DraftSummary[] {
+  return drafts.filter((draft) => {
+    // Filter by type
+    if (filters.type && draft.type !== filters.type) {
+      return false;
+    }
+
+    // Filter by search query
+    if (filters.search) {
+      const query = filters.search.toLowerCase();
+      const matchesName = draft.name.toLowerCase().includes(query);
+      const matchesDesc = draft.description?.toLowerCase().includes(query);
+      if (!matchesName && !matchesDesc) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Options for useDrafts hook
+ */
+interface UseDraftsOptions {
+  /** Auto-refresh interval in ms (0 to disable) */
+  refreshInterval?: number;
+  /** Initial sort field */
+  sortBy?: DraftSortOption;
+  /** Initial sort direction */
+  sortDirection?: 'asc' | 'desc';
+}
+
+/**
+ * Hook for managing draft models
+ */
+export function useDrafts(options: UseDraftsOptions = {}) {
+  const {
+    refreshInterval = 0,
+    sortBy: initialSortBy = 'updatedAt',
+    sortDirection: initialSortDirection = 'desc',
+  } = options;
+
+  const [drafts, setDrafts] = useState<DraftSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [sortBy, setSortBy] = useState<DraftSortOption>(initialSortBy);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(initialSortDirection);
+  const [filters, setFilters] = useState<DraftFilterOptions>({});
+
+  // Load drafts from storage
+  const loadDrafts = useCallback(() => {
+    setIsLoading(true);
+
+    try {
+      const items = getItemsByPrefix<unknown>(DRAFT_KEY_PREFIX);
+      const now = Date.now();
+
+      const summaries: DraftSummary[] = [];
+
+      for (const item of items) {
+        // Check if draft is expired
+        const raw = getRawItem<unknown>(item.key);
+        if (raw?.expiresAt && raw.expiresAt < now) {
+          removeItem(item.key);
+          continue;
+        }
+
+        // Check if draft is too old (even without explicit expiry)
+        if (item.updatedAt && now - item.updatedAt > DRAFT_TTL_MS) {
+          removeItem(item.key);
+          continue;
+        }
+
+        const summary = extractDraftSummary(item.key, item.data);
+        if (summary) {
+          summaries.push(summary);
+        }
+      }
+
+      setDrafts(summaries);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Initial load
+  useEffect(() => {
+    loadDrafts();
+  }, [loadDrafts]);
+
+  // Auto-refresh
+  useEffect(() => {
+    if (refreshInterval <= 0) return;
+
+    const interval = setInterval(loadDrafts, refreshInterval);
+    return () => clearInterval(interval);
+  }, [refreshInterval, loadDrafts]);
+
+  // Delete a draft
+  const deleteDraft = useCallback((id: string) => {
+    removeItem(`${DRAFT_KEY_PREFIX}${id}`);
+    setDrafts((prev) => prev.filter((d) => d.id !== id));
+  }, []);
+
+  // Delete multiple drafts
+  const deleteDrafts = useCallback((ids: string[]) => {
+    for (const id of ids) {
+      removeItem(`${DRAFT_KEY_PREFIX}${id}`);
+    }
+    const idSet = new Set(ids);
+    setDrafts((prev) => prev.filter((d) => !idSet.has(d.id)));
+  }, []);
+
+  // Get processed drafts (sorted and filtered)
+  const processedDrafts = sortDrafts(
+    filterDrafts(drafts, filters),
+    sortBy,
+    sortDirection
+  );
+
+  // Toggle sort direction
+  const toggleSort = useCallback((field: DraftSortOption) => {
+    if (sortBy === field) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(field);
+      setSortDirection('desc');
+    }
+  }, [sortBy]);
+
+  return {
+    drafts: processedDrafts,
+    allDrafts: drafts,
+    isLoading,
+    isEmpty: drafts.length === 0,
+    sortBy,
+    sortDirection,
+    filters,
+    setFilters,
+    toggleSort,
+    deleteDraft,
+    deleteDrafts,
+    refresh: loadDrafts,
+  };
+}

--- a/frontend/src/features/Dashboard/index.ts
+++ b/frontend/src/features/Dashboard/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Dashboard Feature Module
+ *
+ * Provides dashboard components for managing draft models.
+ */
+
+// Components
+export { DraftsDashboard } from './components/DraftsDashboard';
+export { DraftCard } from './components/DraftCard';
+
+// Hooks
+export { useDrafts } from './hooks/useDrafts';
+
+// Types
+export type {
+  DraftSummary,
+  DraftType,
+  DraftSortOption,
+  DraftFilterOptions,
+  DashboardState,
+} from './types/draft';

--- a/frontend/src/features/Dashboard/types/draft.ts
+++ b/frontend/src/features/Dashboard/types/draft.ts
@@ -1,0 +1,67 @@
+/**
+ * Draft Types
+ *
+ * Type definitions for draft models in the dashboard.
+ */
+
+/**
+ * Draft model summary for display
+ */
+export interface DraftSummary {
+  /** Unique draft ID */
+  id: string;
+  /** Draft name or title */
+  name: string;
+  /** Draft type (model-setup, review, export) */
+  type: DraftType;
+  /** Current step index */
+  currentStep: number;
+  /** Total number of steps */
+  totalSteps: number;
+  /** Completion percentage (0-100) */
+  completionPercentage: number;
+  /** When the draft was created */
+  createdAt: Date;
+  /** When the draft was last modified */
+  updatedAt: Date;
+  /** Brief description or summary */
+  description?: string;
+}
+
+/**
+ * Draft type for categorization
+ */
+export type DraftType = 'model-setup' | 'model-review' | 'model-export' | 'unknown';
+
+/**
+ * Sort options for drafts
+ */
+export type DraftSortOption = 'updatedAt' | 'createdAt' | 'name' | 'completion';
+
+/**
+ * Filter options for drafts
+ */
+export interface DraftFilterOptions {
+  /** Filter by type */
+  type?: DraftType;
+  /** Search query */
+  search?: string;
+}
+
+/**
+ * Dashboard view state
+ */
+export interface DashboardState {
+  /** All drafts */
+  drafts: DraftSummary[];
+  /** Currently selected draft IDs */
+  selectedIds: string[];
+  /** Sort order */
+  sortBy: DraftSortOption;
+  /** Sort direction */
+  sortDirection: 'asc' | 'desc';
+  /** Filter options */
+  filters: DraftFilterOptions;
+  /** Loading state */
+  isLoading: boolean;
+}

--- a/frontend/src/features/Map/components/DrawingToolbar.tsx
+++ b/frontend/src/features/Map/components/DrawingToolbar.tsx
@@ -1,4 +1,5 @@
-import { useDrawing } from '../hooks/useDrawing';
+import React from 'react';
+import { useDraw } from '../context/DrawContext';
 import type { DrawingMode, DrawnFeature } from '../types/geometry';
 
 /**
@@ -26,9 +27,9 @@ interface ToolButton {
 }
 
 const TOOLS: ToolButton[] = [
-  { mode: 'point', label: 'Point', icon: '📍', title: 'Draw a point' },
-  { mode: 'line', label: 'Line', icon: '📏', title: 'Draw a line' },
-  { mode: 'polygon', label: 'Polygon', icon: '⬡', title: 'Draw a polygon' },
+  { mode: 'point', label: 'Point', icon: '📍', title: 'Draw a point (click on map)' },
+  { mode: 'line', label: 'Line', icon: '📏', title: 'Draw a line (double-click to finish)' },
+  { mode: 'polygon', label: 'Polygon', icon: '⬡', title: 'Draw a polygon (double-click to finish)' },
 ];
 
 /**
@@ -44,8 +45,7 @@ const POSITION_STYLES: Record<string, React.CSSProperties> = {
 /**
  * DrawingToolbar provides UI controls for map drawing operations.
  *
- * Includes buttons for point, line, and polygon drawing modes,
- * plus a delete button for removing selected features.
+ * Uses the shared DrawContext so it doesn't conflict with MeasurementTool.
  *
  * @example
  * ```tsx
@@ -63,10 +63,18 @@ export function DrawingToolbar({
   position = 'top-left',
   className = '',
 }: DrawingToolbarProps) {
-  const { state, setMode, deleteSelected, deleteAll, isReady } = useDrawing({
-    onCreate,
-    onDelete,
-  });
+  const { state, setMode, deleteSelected, deleteAll, isReady, onCreateSubscribe, onDeleteSubscribe } = useDraw();
+
+  // Subscribe to events
+  React.useEffect(() => {
+    if (!onCreate) return;
+    return onCreateSubscribe(onCreate);
+  }, [onCreate, onCreateSubscribe]);
+
+  React.useEffect(() => {
+    if (!onDelete) return;
+    return onDeleteSubscribe(onDelete);
+  }, [onDelete, onDeleteSubscribe]);
 
   if (!isReady) {
     return null;

--- a/frontend/src/features/Map/components/MapContainer.tsx
+++ b/frontend/src/features/Map/components/MapContainer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, ReactNode } from 'react';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { useMapInternal } from '../context/MapContext';
+import { DrawProvider } from '../context/DrawContext';
 import { MapOptions, DEFAULT_MAP_OPTIONS } from '../types';
 
 /**
@@ -135,7 +136,9 @@ export function MapContainer({
   return (
     <div className={`map-container ${className}`} style={containerStyle}>
       <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
-      {children}
+      <DrawProvider>
+        {children}
+      </DrawProvider>
     </div>
   );
 }

--- a/frontend/src/features/Map/components/MeasurementTool.tsx
+++ b/frontend/src/features/Map/components/MeasurementTool.tsx
@@ -1,4 +1,28 @@
-import { useMeasurement } from '../hooks/useMeasurement';
+import React, { useCallback, useState, useEffect } from 'react';
+import { useDraw } from '../context/DrawContext';
+import {
+  calculateLineLength,
+  calculatePolygonArea,
+  calculatePolygonPerimeter,
+  formatDistance,
+  formatArea,
+} from '../../../shared/utils/geometry';
+import type { DrawnFeature, LineFeature, PolygonFeature } from '../types/geometry';
+
+/**
+ * Measurement mode
+ */
+type MeasurementMode = 'distance' | 'area' | 'none';
+
+/**
+ * Measurement result
+ */
+interface MeasurementResult {
+  type: MeasurementMode;
+  value: number;
+  formatted: string;
+  perimeter?: string;
+}
 
 /**
  * Props for MeasurementTool component
@@ -14,33 +38,86 @@ interface MeasurementToolProps {
  * Position style mapping
  */
 const POSITION_STYLES: Record<string, React.CSSProperties> = {
-  'top-left': { top: '10px', left: '200px' },
+  'top-left': { top: '200px', left: '10px' },
   'top-right': { top: '10px', right: '10px' },
-  'bottom-left': { bottom: '30px', left: '200px' },
+  'bottom-left': { bottom: '30px', left: '10px' },
   'bottom-right': { bottom: '30px', right: '10px' },
 };
 
 /**
  * MeasurementTool provides UI for measuring distances and areas on the map.
  *
- * Features:
- * - Distance measurement (draw a line)
- * - Area measurement (draw a polygon)
- * - Results displayed in metric units
- * - Clear button to reset
+ * Uses the shared DrawContext so it works alongside DrawingToolbar.
  *
  * @example
  * ```tsx
  * <MapContainer>
- *   <MeasurementTool position="top-left" />
+ *   <MeasurementTool position="bottom-left" />
  * </MapContainer>
  * ```
  */
 export function MeasurementTool({
-  position = 'top-left',
+  position = 'bottom-left',
   className = '',
 }: MeasurementToolProps) {
-  const { mode, result, measureDistance, measureArea, clear, isActive } = useMeasurement();
+  const { setMode, deleteAll, isReady, onCreateSubscribe } = useDraw();
+  const [measureMode, setMeasureMode] = useState<MeasurementMode>('none');
+  const [result, setResult] = useState<MeasurementResult | null>(null);
+
+  // Handle feature creation for measurements
+  const handleCreate = useCallback((features: DrawnFeature[]) => {
+    if (features.length === 0 || measureMode === 'none') return;
+
+    const feature = features[0];
+
+    if (feature.geometry.type === 'LineString' && measureMode === 'distance') {
+      const length = calculateLineLength(feature as LineFeature);
+      setResult({
+        type: 'distance',
+        value: length,
+        formatted: formatDistance(length),
+      });
+    } else if (feature.geometry.type === 'Polygon' && measureMode === 'area') {
+      const area = calculatePolygonArea(feature as PolygonFeature);
+      const perimeter = calculatePolygonPerimeter(feature as PolygonFeature);
+      setResult({
+        type: 'area',
+        value: area,
+        formatted: formatArea(area),
+        perimeter: formatDistance(perimeter),
+      });
+    }
+  }, [measureMode]);
+
+  // Subscribe to create events
+  useEffect(() => {
+    return onCreateSubscribe(handleCreate);
+  }, [onCreateSubscribe, handleCreate]);
+
+  const measureDistance = useCallback(() => {
+    setMeasureMode('distance');
+    setResult(null);
+    deleteAll();
+    setMode('line');
+  }, [setMode, deleteAll]);
+
+  const measureArea = useCallback(() => {
+    setMeasureMode('area');
+    setResult(null);
+    deleteAll();
+    setMode('polygon');
+  }, [setMode, deleteAll]);
+
+  const clear = useCallback(() => {
+    setMeasureMode('none');
+    setResult(null);
+    deleteAll();
+    setMode('none');
+  }, [setMode, deleteAll]);
+
+  if (!isReady) {
+    return null;
+  }
 
   const containerStyle: React.CSSProperties = {
     position: 'absolute',
@@ -115,17 +192,17 @@ export function MeasurementTool({
     <div className={`measurement-tool ${className}`} style={containerStyle}>
       <div style={buttonContainerStyle}>
         <button
-          style={mode === 'distance' ? activeButtonStyle : buttonStyle}
+          style={measureMode === 'distance' ? activeButtonStyle : buttonStyle}
           onClick={measureDistance}
-          title="Measure distance"
+          title="Measure distance (double-click to finish)"
         >
           <span style={{ fontSize: '16px' }}>📏</span>
           <span>Distance</span>
         </button>
         <button
-          style={mode === 'area' ? activeButtonStyle : buttonStyle}
+          style={measureMode === 'area' ? activeButtonStyle : buttonStyle}
           onClick={measureArea}
-          title="Measure area"
+          title="Measure area (double-click to finish)"
         >
           <span style={{ fontSize: '16px' }}>⬛</span>
           <span>Area</span>
@@ -146,17 +223,17 @@ export function MeasurementTool({
         </div>
       )}
 
-      {isActive && (
+      {measureMode !== 'none' && (
         <button style={clearButtonStyle} onClick={clear}>
           Clear Measurement
         </button>
       )}
 
-      {mode !== 'none' && !result && (
+      {measureMode !== 'none' && !result && (
         <div style={{ ...resultLabelStyle, marginTop: '8px', textAlign: 'center' }}>
-          {mode === 'distance'
-            ? 'Click points to measure distance'
-            : 'Click points to draw area'}
+          {measureMode === 'distance'
+            ? 'Click points, double-click to finish'
+            : 'Click points, double-click to close'}
         </div>
       )}
     </div>

--- a/frontend/src/features/Map/context/DrawContext.tsx
+++ b/frontend/src/features/Map/context/DrawContext.tsx
@@ -1,0 +1,226 @@
+import { createContext, useContext, ReactNode, useState, useCallback, useEffect, useRef } from 'react';
+import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
+import { useMap } from './MapContext';
+import type { DrawingMode, DrawnFeature, DrawingState } from '../types/geometry';
+
+/**
+ * Draw context value
+ */
+interface DrawContextValue {
+  /** Current drawing state */
+  state: DrawingState;
+  /** Set drawing mode */
+  setMode: (mode: DrawingMode) => void;
+  /** Get all drawn features */
+  getFeatures: () => DrawnFeature[];
+  /** Delete selected features */
+  deleteSelected: () => void;
+  /** Delete all features */
+  deleteAll: () => void;
+  /** Add features programmatically */
+  addFeatures: (features: DrawnFeature[]) => void;
+  /** Whether drawing is ready */
+  isReady: boolean;
+  /** Register a callback for create events */
+  onCreateSubscribe: (callback: (features: DrawnFeature[]) => void) => () => void;
+  /** Register a callback for update events */
+  onUpdateSubscribe: (callback: (features: DrawnFeature[]) => void) => () => void;
+  /** Register a callback for delete events */
+  onDeleteSubscribe: (callback: (features: DrawnFeature[]) => void) => () => void;
+}
+
+const DrawContext = createContext<DrawContextValue | null>(null);
+
+/**
+ * Map drawing mode to MapboxDraw mode
+ */
+function toDrawMode(mode: DrawingMode): string {
+  switch (mode) {
+    case 'point':
+      return 'draw_point';
+    case 'line':
+      return 'draw_line_string';
+    case 'polygon':
+      return 'draw_polygon';
+    default:
+      return 'simple_select';
+  }
+}
+
+/**
+ * Props for DrawProvider
+ */
+interface DrawProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Provides a shared MapboxDraw instance to all child components.
+ *
+ * This solves the conflict between DrawingToolbar and MeasurementTool
+ * by ensuring only one Draw control exists on the map.
+ */
+export function DrawProvider({ children }: DrawProviderProps) {
+  const { map, isLoaded } = useMap();
+  const drawRef = useRef<MapboxDraw | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [state, setState] = useState<DrawingState>({
+    mode: 'none',
+    selectedIds: [],
+    features: [],
+  });
+
+  // Subscriber refs
+  const createSubscribers = useRef<Set<(features: DrawnFeature[]) => void>>(new Set());
+  const updateSubscribers = useRef<Set<(features: DrawnFeature[]) => void>>(new Set());
+  const deleteSubscribers = useRef<Set<(features: DrawnFeature[]) => void>>(new Set());
+
+  // Initialize MapboxDraw once
+  useEffect(() => {
+    if (!map || !isLoaded || drawRef.current) return;
+
+    const draw = new MapboxDraw({
+      displayControlsDefault: false,
+      controls: {},
+      defaultMode: 'simple_select',
+    });
+
+    map.addControl(draw as unknown as mapboxgl.IControl);
+    drawRef.current = draw;
+    setIsReady(true);
+
+    // Event handlers
+    const handleCreate = (e: { features: DrawnFeature[] }) => {
+      setState((prev) => ({
+        ...prev,
+        features: [...prev.features, ...e.features],
+      }));
+      createSubscribers.current.forEach((cb) => cb(e.features));
+    };
+
+    const handleUpdate = (e: { features: DrawnFeature[] }) => {
+      setState((prev) => ({
+        ...prev,
+        features: prev.features.map((f) => {
+          const updated = e.features.find((u) => u.id === f.id);
+          return updated || f;
+        }),
+      }));
+      updateSubscribers.current.forEach((cb) => cb(e.features));
+    };
+
+    const handleDelete = (e: { features: DrawnFeature[] }) => {
+      const deletedIds = new Set(e.features.map((f) => f.id));
+      setState((prev) => ({
+        ...prev,
+        features: prev.features.filter((f) => !deletedIds.has(f.id)),
+        selectedIds: prev.selectedIds.filter((id) => !deletedIds.has(id)),
+      }));
+      deleteSubscribers.current.forEach((cb) => cb(e.features));
+    };
+
+    const handleSelectionChange = (e: { features: DrawnFeature[] }) => {
+      setState((prev) => ({
+        ...prev,
+        selectedIds: e.features.map((f) => String(f.id)),
+      }));
+    };
+
+    map.on('draw.create', handleCreate);
+    map.on('draw.update', handleUpdate);
+    map.on('draw.delete', handleDelete);
+    map.on('draw.selectionchange', handleSelectionChange);
+
+    return () => {
+      map.off('draw.create', handleCreate);
+      map.off('draw.update', handleUpdate);
+      map.off('draw.delete', handleDelete);
+      map.off('draw.selectionchange', handleSelectionChange);
+
+      if (drawRef.current) {
+        map.removeControl(drawRef.current as unknown as mapboxgl.IControl);
+        drawRef.current = null;
+        setIsReady(false);
+      }
+    };
+  }, [map, isLoaded]);
+
+  const setMode = useCallback((mode: DrawingMode) => {
+    if (!drawRef.current) return;
+    drawRef.current.changeMode(toDrawMode(mode));
+    setState((prev) => ({ ...prev, mode }));
+  }, []);
+
+  const getFeatures = useCallback((): DrawnFeature[] => {
+    if (!drawRef.current) return [];
+    return drawRef.current.getAll().features as DrawnFeature[];
+  }, []);
+
+  const deleteSelected = useCallback(() => {
+    if (!drawRef.current) return;
+    const selected = drawRef.current.getSelectedIds();
+    if (selected.length > 0) {
+      drawRef.current.delete(selected);
+    }
+  }, []);
+
+  const deleteAll = useCallback(() => {
+    if (!drawRef.current) return;
+    drawRef.current.deleteAll();
+    setState((prev) => ({ ...prev, features: [], selectedIds: [] }));
+  }, []);
+
+  const addFeatures = useCallback((features: DrawnFeature[]) => {
+    if (!drawRef.current) return;
+    features.forEach((f) => drawRef.current!.add(f));
+    setState((prev) => ({ ...prev, features: [...prev.features, ...features] }));
+  }, []);
+
+  const onCreateSubscribe = useCallback((callback: (features: DrawnFeature[]) => void) => {
+    createSubscribers.current.add(callback);
+    return () => { createSubscribers.current.delete(callback); };
+  }, []);
+
+  const onUpdateSubscribe = useCallback((callback: (features: DrawnFeature[]) => void) => {
+    updateSubscribers.current.add(callback);
+    return () => { updateSubscribers.current.delete(callback); };
+  }, []);
+
+  const onDeleteSubscribe = useCallback((callback: (features: DrawnFeature[]) => void) => {
+    deleteSubscribers.current.add(callback);
+    return () => { deleteSubscribers.current.delete(callback); };
+  }, []);
+
+  const value: DrawContextValue = {
+    state,
+    setMode,
+    getFeatures,
+    deleteSelected,
+    deleteAll,
+    addFeatures,
+    isReady,
+    onCreateSubscribe,
+    onUpdateSubscribe,
+    onDeleteSubscribe,
+  };
+
+  return (
+    <DrawContext.Provider value={value}>
+      {children}
+    </DrawContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the shared draw context.
+ *
+ * @throws Error if used outside of DrawProvider
+ */
+export function useDraw(): DrawContextValue {
+  const context = useContext(DrawContext);
+  if (!context) {
+    throw new Error('useDraw must be used within a DrawProvider');
+  }
+  return context;
+}

--- a/frontend/src/features/Map/index.ts
+++ b/frontend/src/features/Map/index.ts
@@ -15,6 +15,7 @@ export { TerrainControl } from './components/TerrainControl';
 
 // Context
 export { MapProvider, useMap } from './context/MapContext';
+export { DrawProvider, useDraw } from './context/DrawContext';
 
 // Hooks
 export { useDrawing } from './hooks/useDrawing';

--- a/frontend/src/features/Wizard/components/ValidationErrors.tsx
+++ b/frontend/src/features/Wizard/components/ValidationErrors.tsx
@@ -1,0 +1,139 @@
+/**
+ * Validation Errors Component
+ *
+ * Displays validation errors for the current wizard step.
+ */
+
+import React from 'react';
+import { useWizard } from '../context/WizardContext';
+import type { ValidationError } from '../types';
+
+/**
+ * Props for ValidationErrors component
+ */
+interface ValidationErrorsProps {
+  /** Custom errors to display (overrides context errors) */
+  errors?: ValidationError[];
+  /** CSS class */
+  className?: string;
+  /** Show as inline or block */
+  inline?: boolean;
+}
+
+/**
+ * ValidationErrors displays error messages from step validation.
+ *
+ * @example
+ * ```tsx
+ * <ValidationErrors />
+ * ```
+ *
+ * @example With custom errors
+ * ```tsx
+ * <ValidationErrors
+ *   errors={[{ message: 'Custom error', type: 'error' }]}
+ *   inline
+ * />
+ * ```
+ */
+export function ValidationErrors({
+  errors: customErrors,
+  className = '',
+  inline = false,
+}: ValidationErrorsProps) {
+  const { getErrors } = useWizard();
+  const errors = customErrors ?? getErrors();
+
+  if (errors.length === 0) {
+    return null;
+  }
+
+  const containerStyle: React.CSSProperties = {
+    padding: inline ? '8px 12px' : '12px 16px',
+    marginBottom: inline ? '0' : '16px',
+    backgroundColor: '#ffebee',
+    borderRadius: '4px',
+    border: '1px solid #ffcdd2',
+  };
+
+  const listStyle: React.CSSProperties = {
+    margin: 0,
+    padding: errors.length > 1 ? '0 0 0 20px' : 0,
+    listStyle: errors.length > 1 ? 'disc' : 'none',
+  };
+
+  const itemStyle: React.CSSProperties = {
+    color: '#c62828',
+    fontSize: '14px',
+    marginBottom: errors.length > 1 ? '4px' : 0,
+  };
+
+  const warningItemStyle: React.CSSProperties = {
+    ...itemStyle,
+    color: '#e65100',
+  };
+
+  return (
+    <div className={`validation-errors ${className}`} style={containerStyle} role="alert">
+      {errors.length === 1 ? (
+        <span style={errors[0].type === 'warning' ? warningItemStyle : itemStyle}>
+          {errors[0].field && <strong>{errors[0].field}: </strong>}
+          {errors[0].message}
+        </span>
+      ) : (
+        <ul style={listStyle}>
+          {errors.map((error, index) => (
+            <li
+              key={index}
+              style={error.type === 'warning' ? warningItemStyle : itemStyle}
+            >
+              {error.field && <strong>{error.field}: </strong>}
+              {error.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Individual field error display
+ */
+interface FieldErrorProps {
+  /** Field name */
+  field: string;
+  /** CSS class */
+  className?: string;
+}
+
+/**
+ * FieldError shows the error for a specific field from validation.
+ *
+ * @example
+ * ```tsx
+ * <input name="email" />
+ * <FieldError field="email" />
+ * ```
+ */
+export function FieldError({ field, className = '' }: FieldErrorProps) {
+  const { getErrors } = useWizard();
+  const errors = getErrors();
+  const fieldError = errors.find((e) => e.field === field);
+
+  if (!fieldError) {
+    return null;
+  }
+
+  const style: React.CSSProperties = {
+    color: fieldError.type === 'warning' ? '#e65100' : '#c62828',
+    fontSize: '12px',
+    marginTop: '4px',
+  };
+
+  return (
+    <span className={`field-error ${className}`} style={style} role="alert">
+      {fieldError.message}
+    </span>
+  );
+}

--- a/frontend/src/features/Wizard/components/WizardContainer.tsx
+++ b/frontend/src/features/Wizard/components/WizardContainer.tsx
@@ -1,0 +1,77 @@
+/**
+ * Wizard Container Component
+ *
+ * The main wizard wrapper that provides context and layout for wizard steps.
+ */
+
+import React from 'react';
+import { WizardProvider, useWizard } from '../context/WizardContext';
+import type { WizardContainerProps, WizardContextValue } from '../types';
+
+/**
+ * WizardContainer wraps wizard content with the WizardProvider.
+ *
+ * @example
+ * ```tsx
+ * <WizardContainer config={wizardConfig}>
+ *   <WizardProgress />
+ *   <WizardStepContent />
+ *   <WizardNavigation />
+ * </WizardContainer>
+ * ```
+ *
+ * @example With render prop
+ * ```tsx
+ * <WizardContainer config={wizardConfig}>
+ *   {(context) => (
+ *     <div>
+ *       <h1>Step {context.currentStepIndex + 1}</h1>
+ *       {renderStep(context)}
+ *     </div>
+ *   )}
+ * </WizardContainer>
+ * ```
+ */
+export function WizardContainer<T extends Record<string, unknown>>({
+  config,
+  children,
+  className = '',
+  style,
+}: WizardContainerProps<T>) {
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    ...style,
+  };
+
+  // Check if children is a function (render prop pattern)
+  const isRenderProp = typeof children === 'function';
+
+  return (
+    <WizardProvider config={config}>
+      <div className={`wizard-container ${className}`} style={containerStyle}>
+        {isRenderProp ? (
+          <WizardRenderPropContent
+            render={children as (context: WizardContextValue<T>) => React.ReactNode}
+          />
+        ) : (
+          children
+        )}
+      </div>
+    </WizardProvider>
+  );
+}
+
+/**
+ * Helper component for render prop pattern.
+ * Separated to ensure useWizard is called within WizardProvider.
+ */
+function WizardRenderPropContent<T extends Record<string, unknown>>({
+  render,
+}: {
+  render: (context: WizardContextValue<T>) => React.ReactNode;
+}) {
+  const context = useWizard<T>();
+  return <>{render(context)}</>;
+}

--- a/frontend/src/features/Wizard/components/WizardNavigation.tsx
+++ b/frontend/src/features/Wizard/components/WizardNavigation.tsx
@@ -1,0 +1,169 @@
+/**
+ * Wizard Navigation Component
+ *
+ * Provides navigation buttons for the wizard (Back, Next, Finish, Cancel).
+ */
+
+import React, { useCallback, useState } from 'react';
+import { useWizard } from '../context/WizardContext';
+import type { WizardNavigationProps } from '../types';
+
+/**
+ * WizardNavigation renders navigation buttons for the wizard.
+ *
+ * @example
+ * ```tsx
+ * <WizardNavigation
+ *   backLabel="Previous"
+ *   nextLabel="Continue"
+ *   finishLabel="Submit"
+ *   showCancel
+ * />
+ * ```
+ */
+export function WizardNavigation({
+  backLabel = 'Back',
+  nextLabel = 'Next',
+  finishLabel = 'Finish',
+  cancelLabel = 'Cancel',
+  showCancel = false,
+  className = '',
+}: WizardNavigationProps) {
+  const {
+    goNext,
+    goPrev,
+    complete,
+    cancel,
+    isFirstStep,
+    isLastStep,
+    canGoPrev,
+  } = useWizard();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleNext = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      if (isLastStep) {
+        await complete();
+      } else {
+        await goNext();
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [goNext, complete, isLastStep]);
+
+  const handleBack = useCallback(() => {
+    goPrev();
+  }, [goPrev]);
+
+  const handleCancel = useCallback(() => {
+    cancel(false); // Don't delete draft by default
+  }, [cancel]);
+
+  // Handle keyboard navigation
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !isLoading) {
+      handleNext();
+    } else if (e.key === 'Escape' && canGoPrev) {
+      handleBack();
+    }
+  }, [handleNext, handleBack, isLoading, canGoPrev]);
+
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '16px',
+    borderTop: '1px solid #e0e0e0',
+    backgroundColor: '#fafafa',
+  };
+
+  const buttonGroupStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: '8px',
+  };
+
+  const buttonBaseStyle: React.CSSProperties = {
+    padding: '10px 20px',
+    borderRadius: '4px',
+    fontSize: '14px',
+    fontWeight: 500,
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+    border: 'none',
+  };
+
+  const primaryButtonStyle: React.CSSProperties = {
+    ...buttonBaseStyle,
+    backgroundColor: '#1976d2',
+    color: 'white',
+  };
+
+  const secondaryButtonStyle: React.CSSProperties = {
+    ...buttonBaseStyle,
+    backgroundColor: 'white',
+    color: '#333',
+    border: '1px solid #ccc',
+  };
+
+  const cancelButtonStyle: React.CSSProperties = {
+    ...buttonBaseStyle,
+    backgroundColor: 'transparent',
+    color: '#666',
+    border: 'none',
+  };
+
+  const disabledStyle: React.CSSProperties = {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  };
+
+  return (
+    <div
+      className={`wizard-navigation ${className}`}
+      style={containerStyle}
+      onKeyDown={handleKeyDown}
+    >
+      <div style={buttonGroupStyle}>
+        {showCancel && (
+          <button
+            type="button"
+            onClick={handleCancel}
+            style={cancelButtonStyle}
+            disabled={isLoading}
+          >
+            {cancelLabel}
+          </button>
+        )}
+      </div>
+
+      <div style={buttonGroupStyle}>
+        <button
+          type="button"
+          onClick={handleBack}
+          style={{
+            ...secondaryButtonStyle,
+            ...(isFirstStep || isLoading ? disabledStyle : {}),
+          }}
+          disabled={isFirstStep || isLoading}
+        >
+          {backLabel}
+        </button>
+
+        <button
+          type="button"
+          onClick={handleNext}
+          style={{
+            ...primaryButtonStyle,
+            ...(isLoading ? disabledStyle : {}),
+          }}
+          disabled={isLoading}
+        >
+          {isLoading ? 'Loading...' : isLastStep ? finishLabel : nextLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/Wizard/components/WizardProgress.tsx
+++ b/frontend/src/features/Wizard/components/WizardProgress.tsx
@@ -1,0 +1,209 @@
+/**
+ * Wizard Progress Component
+ *
+ * Visual progress indicator showing current step and completion status.
+ */
+
+import React, { useCallback } from 'react';
+import { useWizard } from '../context/WizardContext';
+import type { WizardProgressProps, StepStatus } from '../types';
+
+/**
+ * WizardProgress shows the progress through wizard steps.
+ *
+ * @example
+ * ```tsx
+ * <WizardProgress
+ *   direction="horizontal"
+ *   showNumbers
+ *   allowJump
+ * />
+ * ```
+ */
+export function WizardProgress({
+  direction = 'horizontal',
+  showNumbers = true,
+  allowJump = true,
+  className = '',
+}: WizardProgressProps) {
+  const { state, goToStep, currentStepIndex } = useWizard();
+
+  const handleStepClick = useCallback(async (index: number) => {
+    if (!allowJump) return;
+
+    const targetStep = state.steps[index];
+    if (!targetStep) return;
+
+    // Can only jump to visited/completed steps
+    if (targetStep.visited || index < currentStepIndex) {
+      await goToStep(index);
+    }
+  }, [allowJump, state.steps, currentStepIndex, goToStep]);
+
+  const isHorizontal = direction === 'horizontal';
+
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: isHorizontal ? 'row' : 'column',
+    alignItems: isHorizontal ? 'center' : 'flex-start',
+    justifyContent: isHorizontal ? 'space-between' : 'flex-start',
+    padding: '16px',
+    gap: isHorizontal ? '4px' : '8px',
+    backgroundColor: '#f5f5f5',
+    borderBottom: '1px solid #e0e0e0',
+  };
+
+  return (
+    <div className={`wizard-progress ${className}`} style={containerStyle}>
+      {state.steps.map((stepState, index) => (
+        <React.Fragment key={stepState.step.id}>
+          <StepIndicator
+            index={index}
+            stepState={stepState}
+            isCurrent={index === currentStepIndex}
+            isClickable={allowJump && (stepState.visited || index < currentStepIndex)}
+            showNumber={showNumbers}
+            onClick={() => handleStepClick(index)}
+            direction={direction}
+          />
+          {index < state.steps.length - 1 && (
+            <StepConnector
+              isCompleted={stepState.status === 'completed'}
+              direction={direction}
+            />
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Individual step indicator
+ */
+interface StepIndicatorProps {
+  index: number;
+  stepState: { step: { name: string; icon?: string }; status: StepStatus; visited: boolean };
+  isCurrent: boolean;
+  isClickable: boolean;
+  showNumber: boolean;
+  onClick: () => void;
+  direction: 'horizontal' | 'vertical';
+}
+
+function StepIndicator({
+  index,
+  stepState,
+  isCurrent,
+  isClickable,
+  showNumber,
+  onClick,
+  direction,
+}: StepIndicatorProps) {
+  const { step, status } = stepState;
+  const isHorizontal = direction === 'horizontal';
+
+  const getStatusColor = () => {
+    switch (status) {
+      case 'completed':
+        return '#4caf50';
+      case 'error':
+        return '#f44336';
+      case 'current':
+        return '#1976d2';
+      case 'skipped':
+        return '#9e9e9e';
+      default:
+        return '#bdbdbd';
+    }
+  };
+
+  const getStatusIcon = () => {
+    switch (status) {
+      case 'completed':
+        return '✓';
+      case 'error':
+        return '!';
+      case 'skipped':
+        return '−';
+      default:
+        return showNumber ? String(index + 1) : step.icon || '';
+    }
+  };
+
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: isHorizontal ? 'column' : 'row',
+    alignItems: 'center',
+    gap: '8px',
+    cursor: isClickable ? 'pointer' : 'default',
+    opacity: status === 'pending' && !isCurrent ? 0.6 : 1,
+    transition: 'opacity 0.2s',
+  };
+
+  const circleStyle: React.CSSProperties = {
+    width: '32px',
+    height: '32px',
+    borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: '14px',
+    fontWeight: 600,
+    backgroundColor: isCurrent ? getStatusColor() : 'white',
+    color: isCurrent ? 'white' : getStatusColor(),
+    border: `2px solid ${getStatusColor()}`,
+    transition: 'all 0.2s',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: '12px',
+    fontWeight: isCurrent ? 600 : 400,
+    color: isCurrent ? '#333' : '#666',
+    whiteSpace: 'nowrap',
+    maxWidth: isHorizontal ? '80px' : 'none',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  };
+
+  return (
+    <div
+      style={containerStyle}
+      onClick={isClickable ? onClick : undefined}
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (isClickable && (e.key === 'Enter' || e.key === ' ')) {
+          onClick();
+        }
+      }}
+      aria-current={isCurrent ? 'step' : undefined}
+    >
+      <div style={circleStyle}>{getStatusIcon()}</div>
+      <span style={labelStyle}>{step.name}</span>
+    </div>
+  );
+}
+
+/**
+ * Connector line between steps
+ */
+interface StepConnectorProps {
+  isCompleted: boolean;
+  direction: 'horizontal' | 'vertical';
+}
+
+function StepConnector({ isCompleted, direction }: StepConnectorProps) {
+  const isHorizontal = direction === 'horizontal';
+
+  const style: React.CSSProperties = {
+    flex: isHorizontal ? 1 : 'none',
+    height: isHorizontal ? '2px' : '20px',
+    width: isHorizontal ? 'auto' : '2px',
+    marginLeft: isHorizontal ? '0' : '15px',
+    backgroundColor: isCompleted ? '#4caf50' : '#e0e0e0',
+    transition: 'background-color 0.2s',
+  };
+
+  return <div style={style} />;
+}

--- a/frontend/src/features/Wizard/components/WizardStepContent.tsx
+++ b/frontend/src/features/Wizard/components/WizardStepContent.tsx
@@ -1,0 +1,97 @@
+/**
+ * Wizard Step Content Component
+ *
+ * Wrapper for step content with common layout and header.
+ */
+
+import React from 'react';
+import { useWizard } from '../context/WizardContext';
+import { ValidationErrors } from './ValidationErrors';
+
+/**
+ * Props for WizardStepContent
+ */
+interface WizardStepContentProps {
+  /** Step content */
+  children: React.ReactNode;
+  /** Show step title */
+  showTitle?: boolean;
+  /** Show step description */
+  showDescription?: boolean;
+  /** Show validation errors */
+  showErrors?: boolean;
+  /** CSS class */
+  className?: string;
+}
+
+/**
+ * WizardStepContent provides consistent layout for step content.
+ *
+ * @example
+ * ```tsx
+ * <WizardStepContent showTitle showDescription>
+ *   <form>
+ *     <input name="field1" />
+ *   </form>
+ * </WizardStepContent>
+ * ```
+ */
+export function WizardStepContent({
+  children,
+  showTitle = true,
+  showDescription = true,
+  showErrors = true,
+  className = '',
+}: WizardStepContentProps) {
+  const { currentStep, currentStepIndex, totalSteps } = useWizard();
+
+  const containerStyle: React.CSSProperties = {
+    flex: 1,
+    padding: '24px',
+    overflowY: 'auto',
+  };
+
+  const headerStyle: React.CSSProperties = {
+    marginBottom: '24px',
+  };
+
+  const titleStyle: React.CSSProperties = {
+    fontSize: '24px',
+    fontWeight: 600,
+    color: '#333',
+    margin: 0,
+    marginBottom: currentStep.description && showDescription ? '8px' : 0,
+  };
+
+  const stepCountStyle: React.CSSProperties = {
+    fontSize: '14px',
+    color: '#666',
+    marginBottom: '8px',
+  };
+
+  const descriptionStyle: React.CSSProperties = {
+    fontSize: '14px',
+    color: '#666',
+    margin: 0,
+  };
+
+  return (
+    <div className={`wizard-step-content ${className}`} style={containerStyle}>
+      {(showTitle || showDescription) && (
+        <div style={headerStyle}>
+          <div style={stepCountStyle}>
+            Step {currentStepIndex + 1} of {totalSteps}
+          </div>
+          {showTitle && <h2 style={titleStyle}>{currentStep.name}</h2>}
+          {showDescription && currentStep.description && (
+            <p style={descriptionStyle}>{currentStep.description}</p>
+          )}
+        </div>
+      )}
+
+      {showErrors && <ValidationErrors />}
+
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/features/Wizard/context/WizardContext.tsx
+++ b/frontend/src/features/Wizard/context/WizardContext.tsx
@@ -1,0 +1,227 @@
+/**
+ * Wizard Context
+ *
+ * Provides wizard state and navigation to all child components.
+ */
+
+import { createContext, useContext, useCallback, useEffect, ReactNode } from 'react';
+import { useWizardState } from '../hooks/useWizardState';
+import type {
+  WizardContextValue,
+  WizardConfig,
+  ValidationResult,
+  ValidationError,
+} from '../types';
+
+// Create context with generic type
+const WizardContext = createContext<WizardContextValue | null>(null);
+
+/**
+ * Props for WizardProvider
+ */
+interface WizardProviderProps<T extends Record<string, unknown>> {
+  /** Wizard configuration */
+  config: WizardConfig<T>;
+  /** Children */
+  children: ReactNode;
+}
+
+/**
+ * Provides wizard context to child components
+ */
+export function WizardProvider<T extends Record<string, unknown>>({
+  config,
+  children,
+}: WizardProviderProps<T>) {
+  const {
+    steps,
+    initialData,
+    draftId,
+    storageKey,
+    validators,
+    onComplete,
+    onCancel,
+    onStepChange,
+    autoSaveDelay,
+  } = config;
+
+  const {
+    state,
+    currentStep,
+    currentStepIndex,
+    totalSteps,
+    isFirstStep,
+    isLastStep,
+    goNext: stateGoNext,
+    goPrev: stateGoPrev,
+    goToStep: stateGoToStep,
+    updateData,
+    setField,
+    getData,
+    complete: stateComplete,
+    cancel: stateCancel,
+    validateStep,
+    getErrors,
+  } = useWizardState<T>({
+    steps,
+    initialData,
+    draftId,
+    storageKey,
+    validators,
+    autoSaveDelay,
+  });
+
+  // Previous step index for change detection
+  const prevStepIndexRef = { current: currentStepIndex };
+
+  // Trigger step change callback
+  useEffect(() => {
+    if (prevStepIndexRef.current !== currentStepIndex && onStepChange) {
+      onStepChange(prevStepIndexRef.current, currentStepIndex, state.data);
+    }
+    prevStepIndexRef.current = currentStepIndex;
+  }, [currentStepIndex, onStepChange, state.data]);
+
+  // Wrapped goNext with step change callback
+  const goNext = useCallback(async (): Promise<boolean> => {
+    const success = await stateGoNext();
+    return success;
+  }, [stateGoNext]);
+
+  // Wrapped goPrev
+  const goPrev = useCallback(() => {
+    stateGoPrev();
+  }, [stateGoPrev]);
+
+  // Wrapped goToStep
+  const goToStep = useCallback(async (index: number): Promise<boolean> => {
+    const success = await stateGoToStep(index);
+    return success;
+  }, [stateGoToStep]);
+
+  // Complete with callback
+  const complete = useCallback(async (): Promise<boolean> => {
+    const success = await stateComplete();
+    if (success && onComplete) {
+      await onComplete(state.data);
+    }
+    return success;
+  }, [stateComplete, onComplete, state.data]);
+
+  // Cancel with callback
+  const cancel = useCallback((deleteDraft = false) => {
+    if (onCancel) {
+      onCancel(state.data, state.draftId);
+    }
+    stateCancel(deleteDraft);
+  }, [onCancel, stateCancel, state.data, state.draftId]);
+
+  // Validation result for current step
+  const currentValidation = state.steps[currentStepIndex]?.validation;
+  const canGoNext = currentValidation?.isValid !== false;
+  const canGoPrev = !isFirstStep;
+
+  const value: WizardContextValue<T> = {
+    state,
+    currentStep,
+    currentStepIndex,
+    totalSteps,
+    isFirstStep,
+    isLastStep,
+    canGoNext,
+    canGoPrev,
+    goNext,
+    goPrev,
+    goToStep,
+    updateData,
+    setField,
+    getData,
+    complete,
+    cancel,
+    validateStep,
+    getErrors,
+  };
+
+  return (
+    <WizardContext.Provider value={value as WizardContextValue}>
+      {children}
+    </WizardContext.Provider>
+  );
+}
+
+/**
+ * Hook to access wizard context
+ *
+ * @throws Error if used outside of WizardProvider
+ */
+export function useWizard<T extends Record<string, unknown> = Record<string, unknown>>(): WizardContextValue<T> {
+  const context = useContext(WizardContext);
+  if (!context) {
+    throw new Error('useWizard must be used within a WizardProvider');
+  }
+  return context as WizardContextValue<T>;
+}
+
+/**
+ * Hook to access wizard validation
+ */
+export function useWizardValidation(): {
+  validateStep: () => Promise<ValidationResult>;
+  getErrors: () => ValidationError[];
+  hasErrors: boolean;
+} {
+  const { validateStep, getErrors, state, currentStepIndex } = useWizard();
+  const currentValidation = state.steps[currentStepIndex]?.validation;
+
+  return {
+    validateStep,
+    getErrors,
+    hasErrors: currentValidation?.isValid === false,
+  };
+}
+
+/**
+ * Hook to access wizard navigation
+ */
+export function useWizardNavigation() {
+  const {
+    goNext,
+    goPrev,
+    goToStep,
+    complete,
+    cancel,
+    isFirstStep,
+    isLastStep,
+    canGoNext,
+    canGoPrev,
+    currentStepIndex,
+    totalSteps,
+  } = useWizard();
+
+  return {
+    goNext,
+    goPrev,
+    goToStep,
+    complete,
+    cancel,
+    isFirstStep,
+    isLastStep,
+    canGoNext,
+    canGoPrev,
+    currentStepIndex,
+    totalSteps,
+  };
+}
+
+/**
+ * Hook to access wizard data
+ */
+export function useWizardData<T extends Record<string, unknown> = Record<string, unknown>>() {
+  const { getData, updateData, setField } = useWizard<T>();
+
+  return {
+    data: getData(),
+    updateData,
+    setField,
+  };
+}

--- a/frontend/src/features/Wizard/hooks/useWizardState.ts
+++ b/frontend/src/features/Wizard/hooks/useWizardState.ts
@@ -1,0 +1,350 @@
+/**
+ * Wizard State Hook
+ *
+ * Manages wizard form data with localStorage persistence.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  getItem,
+  setItem,
+  removeItem,
+  generateDraftId,
+} from '../../../shared/utils/storage';
+import type {
+  WizardState,
+  WizardStep,
+  StepState,
+  ValidationResult,
+  StepValidator,
+} from '../types';
+
+/**
+ * Default validation result (valid)
+ */
+const VALID_RESULT: ValidationResult = { isValid: true, errors: [] };
+
+/**
+ * Options for useWizardState hook
+ */
+interface UseWizardStateOptions<T> {
+  /** Step configurations */
+  steps: WizardStep[];
+  /** Initial data */
+  initialData?: Partial<T>;
+  /** Existing draft ID to resume */
+  draftId?: string;
+  /** Storage key prefix */
+  storageKey?: string;
+  /** Validators for each step */
+  validators?: Record<string, StepValidator<T>>;
+  /** Auto-save debounce delay */
+  autoSaveDelay?: number;
+}
+
+/**
+ * Storage key for wizard drafts
+ */
+const DRAFT_KEY_PREFIX = 'nomad_wizard_draft_';
+
+/**
+ * Hook for managing wizard state with persistence
+ */
+export function useWizardState<T extends Record<string, unknown>>(
+  options: UseWizardStateOptions<T>
+) {
+  const {
+    steps,
+    initialData = {} as T,
+    draftId: existingDraftId,
+    storageKey = DRAFT_KEY_PREFIX,
+    validators = {},
+    autoSaveDelay = 500,
+  } = options;
+
+  // Initialize or restore state
+  const initializeState = useCallback((): WizardState<T> => {
+    // Try to restore from existing draft
+    if (existingDraftId) {
+      const saved = getItem<WizardState<T>>(`${storageKey}${existingDraftId}`);
+      if (saved) {
+        return saved;
+      }
+    }
+
+    // Create new state
+    const now = Date.now();
+    const draftId = existingDraftId || generateDraftId();
+
+    const stepStates: StepState[] = steps.map((step, index) => ({
+      step,
+      status: index === 0 ? 'current' : 'pending',
+      visited: index === 0,
+    }));
+
+    return {
+      draftId,
+      currentStepIndex: 0,
+      steps: stepStates,
+      data: initialData as T,
+      isComplete: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }, [existingDraftId, steps, initialData, storageKey]);
+
+  const [state, setState] = useState<WizardState<T>>(initializeState);
+
+  // Debounced save ref
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSavedRef = useRef<string>('');
+
+  // Save to localStorage
+  const saveToStorage = useCallback((newState: WizardState<T>) => {
+    const key = `${storageKey}${newState.draftId}`;
+    const serialized = JSON.stringify(newState);
+
+    // Only save if changed
+    if (serialized !== lastSavedRef.current) {
+      setItem(key, newState);
+      lastSavedRef.current = serialized;
+    }
+  }, [storageKey]);
+
+  // Debounced auto-save
+  useEffect(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+
+    saveTimeoutRef.current = setTimeout(() => {
+      saveToStorage(state);
+    }, autoSaveDelay);
+
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, [state, saveToStorage, autoSaveDelay]);
+
+  // Validate a step
+  const validateStep = useCallback(async (stepIndex: number): Promise<ValidationResult> => {
+    const stepState = state.steps[stepIndex];
+    if (!stepState) return VALID_RESULT;
+
+    const validator = validators[stepState.step.id];
+    if (!validator) return VALID_RESULT;
+
+    try {
+      const result = await validator(state.data);
+      return result;
+    } catch (e) {
+      return {
+        isValid: false,
+        errors: [{ message: String(e), type: 'error' }],
+      };
+    }
+  }, [state.steps, state.data, validators]);
+
+  // Update step states based on current index
+  const updateStepStates = useCallback((
+    currentSteps: StepState[],
+    newIndex: number,
+    validation?: ValidationResult
+  ): StepState[] => {
+    return currentSteps.map((s, i) => {
+      if (i < newIndex) {
+        // Previous steps are completed (unless they had errors)
+        return {
+          ...s,
+          status: s.validation?.isValid === false ? 'error' : 'completed',
+          visited: true,
+        };
+      } else if (i === newIndex) {
+        return {
+          ...s,
+          status: 'current',
+          visited: true,
+          validation,
+        };
+      } else {
+        // Future steps remain pending/skipped
+        return s;
+      }
+    });
+  }, []);
+
+  // Go to next step
+  const goNext = useCallback(async (): Promise<boolean> => {
+    const { currentStepIndex: current, steps: currentSteps } = state;
+
+    // Validate current step
+    const validation = await validateStep(current);
+    if (!validation.isValid) {
+      setState(prev => ({
+        ...prev,
+        updatedAt: Date.now(),
+        steps: prev.steps.map((s, i) =>
+          i === current ? { ...s, validation, status: 'error' } : s
+        ),
+      }));
+      return false;
+    }
+
+    // Check if we're on the last step
+    if (current >= currentSteps.length - 1) {
+      return false;
+    }
+
+    const nextIndex = current + 1;
+    setState(prev => ({
+      ...prev,
+      currentStepIndex: nextIndex,
+      updatedAt: Date.now(),
+      steps: updateStepStates(prev.steps, nextIndex, { isValid: true, errors: [] }),
+    }));
+
+    return true;
+  }, [state, validateStep, updateStepStates]);
+
+  // Go to previous step
+  const goPrev = useCallback(() => {
+    setState(prev => {
+      if (prev.currentStepIndex === 0) return prev;
+
+      const prevIndex = prev.currentStepIndex - 1;
+      return {
+        ...prev,
+        currentStepIndex: prevIndex,
+        updatedAt: Date.now(),
+        steps: updateStepStates(prev.steps, prevIndex),
+      };
+    });
+  }, [updateStepStates]);
+
+  // Jump to specific step
+  const goToStep = useCallback(async (index: number): Promise<boolean> => {
+    if (index < 0 || index >= state.steps.length) return false;
+
+    // Can only jump to visited steps or current step
+    const targetStep = state.steps[index];
+    if (!targetStep.visited && index > state.currentStepIndex) {
+      return false;
+    }
+
+    // If jumping forward, validate current step first
+    if (index > state.currentStepIndex) {
+      const validation = await validateStep(state.currentStepIndex);
+      if (!validation.isValid) {
+        setState(prev => ({
+          ...prev,
+          updatedAt: Date.now(),
+          steps: prev.steps.map((s, i) =>
+            i === prev.currentStepIndex ? { ...s, validation, status: 'error' } : s
+          ),
+        }));
+        return false;
+      }
+    }
+
+    setState(prev => ({
+      ...prev,
+      currentStepIndex: index,
+      updatedAt: Date.now(),
+      steps: updateStepStates(prev.steps, index),
+    }));
+
+    return true;
+  }, [state.steps, state.currentStepIndex, validateStep, updateStepStates]);
+
+  // Update data
+  const updateData = useCallback((data: Partial<T>) => {
+    setState(prev => ({
+      ...prev,
+      data: { ...prev.data, ...data },
+      updatedAt: Date.now(),
+    }));
+  }, []);
+
+  // Set individual field
+  const setField = useCallback(<K extends keyof T>(field: K, value: T[K]) => {
+    setState(prev => ({
+      ...prev,
+      data: { ...prev.data, [field]: value },
+      updatedAt: Date.now(),
+    }));
+  }, []);
+
+  // Complete the wizard
+  const complete = useCallback(async (): Promise<boolean> => {
+    // Validate all steps
+    for (let i = 0; i <= state.currentStepIndex; i++) {
+      const validation = await validateStep(i);
+      if (!validation.isValid) {
+        setState(prev => ({
+          ...prev,
+          currentStepIndex: i,
+          updatedAt: Date.now(),
+          steps: prev.steps.map((s, idx) =>
+            idx === i ? { ...s, validation, status: 'error' } : s
+          ),
+        }));
+        return false;
+      }
+    }
+
+    setState(prev => ({
+      ...prev,
+      isComplete: true,
+      updatedAt: Date.now(),
+      steps: prev.steps.map(s => ({
+        ...s,
+        status: s.step.optional && !s.visited ? 'skipped' : 'completed',
+      })),
+    }));
+
+    return true;
+  }, [state.currentStepIndex, validateStep]);
+
+  // Cancel and optionally delete draft
+  const cancel = useCallback((deleteDraft = false) => {
+    if (deleteDraft) {
+      removeItem(`${storageKey}${state.draftId}`);
+    }
+  }, [storageKey, state.draftId]);
+
+  // Delete draft from storage
+  const deleteDraft = useCallback(() => {
+    removeItem(`${storageKey}${state.draftId}`);
+  }, [storageKey, state.draftId]);
+
+  // Force save now
+  const saveNow = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveToStorage(state);
+  }, [saveToStorage, state]);
+
+  return {
+    state,
+    currentStep: state.steps[state.currentStepIndex]?.step ?? steps[0],
+    currentStepIndex: state.currentStepIndex,
+    totalSteps: steps.length,
+    isFirstStep: state.currentStepIndex === 0,
+    isLastStep: state.currentStepIndex === steps.length - 1,
+    goNext,
+    goPrev,
+    goToStep,
+    updateData,
+    setField,
+    getData: () => state.data,
+    complete,
+    cancel,
+    deleteDraft,
+    saveNow,
+    validateStep: () => validateStep(state.currentStepIndex),
+    getErrors: () => state.steps[state.currentStepIndex]?.validation?.errors ?? [],
+  };
+}

--- a/frontend/src/features/Wizard/index.ts
+++ b/frontend/src/features/Wizard/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Wizard Feature Module
+ *
+ * Provides a reusable wizard component system for multi-step workflows.
+ */
+
+// Components
+export { WizardContainer } from './components/WizardContainer';
+export { WizardNavigation } from './components/WizardNavigation';
+export { WizardProgress } from './components/WizardProgress';
+export { WizardStepContent } from './components/WizardStepContent';
+export { ValidationErrors, FieldError } from './components/ValidationErrors';
+
+// Context
+export {
+  WizardProvider,
+  useWizard,
+  useWizardValidation,
+  useWizardNavigation,
+  useWizardData,
+} from './context/WizardContext';
+
+// Hooks
+export { useWizardState } from './hooks/useWizardState';
+
+// Types
+export type {
+  WizardStep,
+  ValidationResult,
+  ValidationError,
+  StepValidator,
+  StepStatus,
+  StepState,
+  WizardState,
+  NavigationDirection,
+  WizardContextValue,
+  WizardConfig,
+  WizardContainerProps,
+  WizardNavigationProps,
+  WizardProgressProps,
+} from './types';

--- a/frontend/src/features/Wizard/types/index.ts
+++ b/frontend/src/features/Wizard/types/index.ts
@@ -1,0 +1,204 @@
+/**
+ * Wizard Types
+ *
+ * Core type definitions for the reusable wizard component system.
+ */
+
+/**
+ * Wizard step configuration
+ */
+export interface WizardStep {
+  /** Unique identifier for this step */
+  id: string;
+  /** Display name for the step */
+  name: string;
+  /** Optional description */
+  description?: string;
+  /** Whether this step can be skipped */
+  optional?: boolean;
+  /** Icon for the step (emoji or icon name) */
+  icon?: string;
+}
+
+/**
+ * Step validation result
+ */
+export interface ValidationResult {
+  /** Whether the step is valid */
+  isValid: boolean;
+  /** Array of error messages */
+  errors: ValidationError[];
+}
+
+/**
+ * Individual validation error
+ */
+export interface ValidationError {
+  /** Field that has the error (optional) */
+  field?: string;
+  /** Error message */
+  message: string;
+  /** Error type for styling */
+  type: 'error' | 'warning';
+}
+
+/**
+ * Step validator function type
+ */
+export type StepValidator<T = unknown> = (data: T) => ValidationResult | Promise<ValidationResult>;
+
+/**
+ * Wizard step status
+ */
+export type StepStatus = 'pending' | 'current' | 'completed' | 'error' | 'skipped';
+
+/**
+ * Internal step state
+ */
+export interface StepState {
+  /** Step configuration */
+  step: WizardStep;
+  /** Current status */
+  status: StepStatus;
+  /** Validation result if validated */
+  validation?: ValidationResult;
+  /** Whether this step has been visited */
+  visited: boolean;
+}
+
+/**
+ * Wizard state
+ */
+export interface WizardState<T = Record<string, unknown>> {
+  /** Unique draft ID */
+  draftId: string;
+  /** Current step index */
+  currentStepIndex: number;
+  /** All step states */
+  steps: StepState[];
+  /** Form data for all steps */
+  data: T;
+  /** Whether the wizard is complete */
+  isComplete: boolean;
+  /** When this draft was created */
+  createdAt: number;
+  /** When this draft was last modified */
+  updatedAt: number;
+}
+
+/**
+ * Wizard navigation direction
+ */
+export type NavigationDirection = 'next' | 'prev' | 'jump';
+
+/**
+ * Wizard context value
+ */
+export interface WizardContextValue<T = Record<string, unknown>> {
+  /** Current wizard state */
+  state: WizardState<T>;
+  /** Current step configuration */
+  currentStep: WizardStep;
+  /** Current step index */
+  currentStepIndex: number;
+  /** Total number of steps */
+  totalSteps: number;
+  /** Whether on the first step */
+  isFirstStep: boolean;
+  /** Whether on the last step */
+  isLastStep: boolean;
+  /** Whether can go to next step (passes validation) */
+  canGoNext: boolean;
+  /** Whether can go to previous step */
+  canGoPrev: boolean;
+  /** Go to next step */
+  goNext: () => Promise<boolean>;
+  /** Go to previous step */
+  goPrev: () => void;
+  /** Jump to a specific step by index */
+  goToStep: (index: number) => Promise<boolean>;
+  /** Update data for current step */
+  updateData: (data: Partial<T>) => void;
+  /** Set data for a specific field */
+  setField: <K extends keyof T>(field: K, value: T[K]) => void;
+  /** Get current step's data */
+  getData: () => T;
+  /** Complete the wizard */
+  complete: () => Promise<boolean>;
+  /** Cancel and optionally delete draft */
+  cancel: (deleteDraft?: boolean) => void;
+  /** Validate current step */
+  validateStep: () => Promise<ValidationResult>;
+  /** Get validation errors for current step */
+  getErrors: () => ValidationError[];
+}
+
+/**
+ * Wizard configuration
+ */
+export interface WizardConfig<T = Record<string, unknown>> {
+  /** Steps configuration */
+  steps: WizardStep[];
+  /** Initial data */
+  initialData?: Partial<T>;
+  /** Existing draft ID to resume */
+  draftId?: string;
+  /** Storage key prefix */
+  storageKey?: string;
+  /** Validators for each step (keyed by step id) */
+  validators?: Record<string, StepValidator<T>>;
+  /** Callback when wizard completes */
+  onComplete?: (data: T) => void | Promise<void>;
+  /** Callback when wizard is cancelled */
+  onCancel?: (data: T, draftId: string) => void;
+  /** Callback on step change */
+  onStepChange?: (fromIndex: number, toIndex: number, data: T) => void;
+  /** Auto-save debounce delay in ms (default: 500) */
+  autoSaveDelay?: number;
+}
+
+/**
+ * Props for wizard container
+ */
+export interface WizardContainerProps<T = Record<string, unknown>> {
+  /** Wizard configuration */
+  config: WizardConfig<T>;
+  /** Children render function or React nodes */
+  children: React.ReactNode | ((context: WizardContextValue<T>) => React.ReactNode);
+  /** CSS class for the container */
+  className?: string;
+  /** Inline styles */
+  style?: React.CSSProperties;
+}
+
+/**
+ * Props for wizard navigation
+ */
+export interface WizardNavigationProps {
+  /** Custom label for back button */
+  backLabel?: string;
+  /** Custom label for next button */
+  nextLabel?: string;
+  /** Custom label for finish button */
+  finishLabel?: string;
+  /** Custom label for cancel button */
+  cancelLabel?: string;
+  /** Show cancel button */
+  showCancel?: boolean;
+  /** CSS class */
+  className?: string;
+}
+
+/**
+ * Props for wizard progress
+ */
+export interface WizardProgressProps {
+  /** Layout direction */
+  direction?: 'horizontal' | 'vertical';
+  /** Show step numbers */
+  showNumbers?: boolean;
+  /** Allow clicking to jump to completed steps */
+  allowJump?: boolean;
+  /** CSS class */
+  className?: string;
+}

--- a/frontend/src/shared/utils/storage.ts
+++ b/frontend/src/shared/utils/storage.ts
@@ -1,0 +1,237 @@
+/**
+ * Local Storage Utilities
+ *
+ * Safe wrappers for localStorage with JSON serialization,
+ * error handling, and optional TTL support.
+ */
+
+/**
+ * Storage item with metadata
+ */
+interface StorageItem<T> {
+  data: T;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt?: number;
+}
+
+/**
+ * Options for storage operations
+ */
+interface StorageOptions {
+  /** Time-to-live in milliseconds */
+  ttl?: number;
+}
+
+/**
+ * Check if localStorage is available
+ */
+export function isStorageAvailable(): boolean {
+  try {
+    const testKey = '__storage_test__';
+    localStorage.setItem(testKey, testKey);
+    localStorage.removeItem(testKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get item from localStorage with JSON parsing
+ */
+export function getItem<T>(key: string): T | null {
+  if (!isStorageAvailable()) return null;
+
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+
+    const item: StorageItem<T> = JSON.parse(raw);
+
+    // Check if expired
+    if (item.expiresAt && Date.now() > item.expiresAt) {
+      localStorage.removeItem(key);
+      return null;
+    }
+
+    return item.data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Set item in localStorage with JSON serialization
+ */
+export function setItem<T>(key: string, data: T, options?: StorageOptions): boolean {
+  if (!isStorageAvailable()) return false;
+
+  try {
+    const now = Date.now();
+    const existing = getRawItem<T>(key);
+
+    const item: StorageItem<T> = {
+      data,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      expiresAt: options?.ttl ? now + options.ttl : undefined,
+    };
+
+    localStorage.setItem(key, JSON.stringify(item));
+    return true;
+  } catch (e) {
+    // Storage might be full
+    console.warn('Failed to save to localStorage:', e);
+    return false;
+  }
+}
+
+/**
+ * Remove item from localStorage
+ */
+export function removeItem(key: string): boolean {
+  if (!isStorageAvailable()) return false;
+
+  try {
+    localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get raw storage item with metadata
+ */
+export function getRawItem<T>(key: string): StorageItem<T> | null {
+  if (!isStorageAvailable()) return null;
+
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get all keys matching a prefix
+ */
+export function getKeysByPrefix(prefix: string): string[] {
+  if (!isStorageAvailable()) return [];
+
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(prefix)) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Get all items matching a prefix
+ */
+export function getItemsByPrefix<T>(prefix: string): Array<{ key: string; data: T; createdAt: number; updatedAt: number }> {
+  const keys = getKeysByPrefix(prefix);
+  const items: Array<{ key: string; data: T; createdAt: number; updatedAt: number }> = [];
+
+  for (const key of keys) {
+    const raw = getRawItem<T>(key);
+    if (raw) {
+      items.push({
+        key,
+        data: raw.data,
+        createdAt: raw.createdAt,
+        updatedAt: raw.updatedAt,
+      });
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Remove all items matching a prefix
+ */
+export function removeByPrefix(prefix: string): number {
+  const keys = getKeysByPrefix(prefix);
+  let removed = 0;
+
+  for (const key of keys) {
+    if (removeItem(key)) {
+      removed++;
+    }
+  }
+
+  return removed;
+}
+
+/**
+ * Clean up expired items
+ */
+export function cleanupExpired(): number {
+  if (!isStorageAvailable()) return 0;
+
+  const now = Date.now();
+  let cleaned = 0;
+
+  for (let i = localStorage.length - 1; i >= 0; i--) {
+    const key = localStorage.key(i);
+    if (!key) continue;
+
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+
+      const item = JSON.parse(raw);
+      if (item.expiresAt && now > item.expiresAt) {
+        localStorage.removeItem(key);
+        cleaned++;
+      }
+    } catch {
+      // Not our format, skip
+    }
+  }
+
+  return cleaned;
+}
+
+/**
+ * Get approximate storage usage
+ */
+export function getStorageUsage(): { used: number; total: number; percentage: number } {
+  if (!isStorageAvailable()) {
+    return { used: 0, total: 0, percentage: 0 };
+  }
+
+  let used = 0;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key) {
+      const value = localStorage.getItem(key);
+      if (value) {
+        used += key.length + value.length;
+      }
+    }
+  }
+
+  // localStorage typically has 5MB limit (5 * 1024 * 1024 bytes)
+  // But characters are 2 bytes in JS strings
+  const total = 5 * 1024 * 1024;
+  const percentage = (used / total) * 100;
+
+  return { used, total, percentage };
+}
+
+/**
+ * Generate a unique ID for drafts
+ */
+export function generateDraftId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 8);
+  return `draft_${timestamp}_${random}`;
+}


### PR DESCRIPTION
## Summary

Implements Phase 4 of Project Nomad frontend - the reusable Wizard component system and Drafts Dashboard.

**Wizard Feature:**
- `WizardContainer` - Main wrapper with provider pattern for multi-step workflows
- `WizardNavigation` - Back/Next/Finish/Cancel buttons with keyboard support
- `WizardProgress` - Visual progress indicator (horizontal/vertical layouts)
- `WizardStepContent` - Step content wrapper with validation error display
- `useWizardState` hook - State management with localStorage persistence
- `ValidationErrors` and `FieldError` components for error display

**Dashboard Feature:**
- `DraftsDashboard` - "Continue where you left off" dashboard view
- `DraftCard` - Individual draft display with progress and actions
- `useDrafts` hook - localStorage draft management with 30-day TTL
- Sorting (modified, created, name, completion)
- Filtering by type and search

**Map Feature Bug Fix:**
- Created shared `DrawContext` to fix DrawingToolbar/MeasurementTool conflict
- Both tools now share a single MapboxDraw instance
- Subscriber pattern for create/update/delete events
- No more duplicate draw controls

**Shared Utilities:**
- `storage.ts` - Safe localStorage wrappers with JSON serialization, TTL support, draft ID generation

## Test Plan

- [x] `npm run build` passes with no errors
- [x] DrawingToolbar and MeasurementTool can coexist without conflicts
- [x] Wizard types and interfaces are properly exported
- [x] Dashboard components compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)