### PR TITLE
Fix CI: update-changes workflow auth for protected main

### DIFF
--- a/.github/workflows/update-changes.yml
+++ b/.github/workflows/update-changes.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Generate CHANGES.md
         run: |


### PR DESCRIPTION
## Summary

- Add `RELEASE_TOKEN` to `update-changes.yml` checkout step so `git push` can write to branch-protected `main`
- The default `GITHUB_TOKEN` was blocked by branch protection on every merge — this has been failing silently since protection was enabled

## Context

`RELEASE_TOKEN` secret was just created in repo settings. `stable-release.yml` and `lts-release.yml` already reference it — this brings `update-changes.yml` in line.