### PR TITLE
Fix CI: release workflow race condition on push

### DIFF
--- a/.github/workflows/lts-release.yml
+++ b/.github/workflows/lts-release.yml
@@ -42,6 +42,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add frontend/package.json
           git commit -m "chore: bump to v${{ steps.newversion.outputs.version }}-lts [skip ci]"
+          git pull --rebase origin lts
           git push
 
       - name: Create git tag

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -56,6 +56,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add frontend/package.json
           git commit -m "chore: bump to v${{ steps.newversion.outputs.version }} [skip ci]"
+          git pull --rebase origin main
           git push
 
       - name: Create git tag


### PR DESCRIPTION
Add git pull --rebase before git push in stable and LTS release workflows. Fixes race condition where Update CHANGES.md pushes to main first, causing the release version bump push to be rejected.