### PR TITLE
Fix CI: update-changes race condition

### DIFF
--- a/.github/workflows/update-changes.yml
+++ b/.github/workflows/update-changes.yml
@@ -36,5 +36,6 @@ jobs:
             echo "No changes to CHANGES.md"
           else
             git commit -m "chore: auto-update CHANGES.md [skip ci]"
+            git pull --rebase origin main
             git push
           fi


### PR DESCRIPTION
Add git pull --rebase before push in update-changes workflow. Same race fix applied to stable-release in #172 -- both workflows trigger on merge to main and can collide.