### PR TITLE
Fix CI: sync stable version bump back to dev (#177)

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -84,3 +84,10 @@ jobs:
           prerelease: false
           generate_release_notes: true
           files: frontend/nomad-frontend-*.tgz
+
+      - name: Sync version back to dev
+        run: |
+          git fetch origin dev
+          git checkout dev
+          git merge main -m "chore: sync v${{ steps.newversion.outputs.version }} from main [skip ci]"
+          git push origin dev


### PR DESCRIPTION
Add post-release step to stable-release workflow that merges main back into dev after publishing. Ensures dev pre-releases reflect the current version instead of showing stale v0.3.0-dev.X tags.