### PR TITLE
fix(installer): install workspace dev deps so tsc is available at build

### DIFF
--- a/scripts/install-nomad-san-metal.sh
+++ b/scripts/install-nomad-san-metal.sh
@@ -359,8 +359,13 @@ build_nomad() {
     print_step "Installing Node.js dependencies..."
     cd "$INSTALL_DIR"
 
-    # Install with dev dependencies
-    env NODE_ENV=development npm install --include=dev
+    # Install with dev dependencies in BOTH root and workspaces. TypeScript
+    # and friends live in backend/ and frontend/ package.json — without
+    # --workspaces the build fails with "tsc: command not found".
+    env NODE_ENV=development npm install \
+        --include=dev \
+        --workspaces \
+        --include-workspace-root
 
     print_step "Rebuilding native modules..."
     npm rebuild


### PR DESCRIPTION
## Summary

Bare-metal install ran `npm install --include=dev` at the root, only resolved root deps, left backend/frontend empty, and the build then failed with `sh: tsc: command not found`. Adds `--workspaces --include-workspace-root` so workspace devDeps install alongside root ones.

## Test plan

- Run `scripts/install-nomad-san-metal.sh` on a clean machine
- Confirm `node_modules/.bin/tsc` exists after install
- Confirm `npm run build` succeeds end-to-end