### PR TITLE
fix(firestarr): hand FireSTARR UTC time + --tz 0 (was tz-mixed)

### DIFF
--- a/backend/src/infrastructure/firestarr/FireSTARREngine.ts
+++ b/backend/src/infrastructure/firestarr/FireSTARREngine.ts
@@ -695,9 +695,15 @@ export class FireSTARREngine implements IFireModelingEngine {
       logger.debug(`Using corrected centroid: lat=${latitude.toFixed(6)}, lon=${longitude.toFixed(6)} (original: lat=${params.latitude.toFixed(6)}, lon=${params.longitude.toFixed(6)})`, 'FireSTARR');
     }
 
-    // Calculate UTC offset from longitude (natural solar timezone)
-    // Each 15° of longitude = 1 hour offset from UTC
-    const utcOffset = Math.round(longitude / 15);
+    // Hand FireSTARR everything in UTC. The old longitude-based solar
+    // timezone approximation (round(longitude/15)) was wrong for two
+    // reasons: (1) it doesn't track real timezones (Hay River is MDT =
+    // UTC-6 in summer, not UTC-8 at longitude -115°), and (2) the
+    // date/time we pass alongside --tz comes from UTC-read getters,
+    // which already encodes the moment in UTC. Mixing a UTC time with a
+    // solar-TZ label caused arrival-raster values to drift by several
+    // hours (refs #236 debugging, 2026-04-23).
+    const utcOffset = 0;
 
     const args: string[] = [
       binaryPath,
@@ -755,9 +761,10 @@ export class FireSTARREngine implements IFireModelingEngine {
    * Formats a date as yyyy-mm-dd.
    */
   private formatDate(date: Date): string {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
+    // UTC readers so behaviour is identical regardless of server TZ.
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   }
 
@@ -765,8 +772,9 @@ export class FireSTARREngine implements IFireModelingEngine {
    * Formats a date's time as HH:MM.
    */
   private formatTime(date: Date): string {
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
+    // UTC readers so the time we hand FireSTARR matches the --tz 0 we pass.
+    const hours = String(date.getUTCHours()).padStart(2, '0');
+    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
     return `${hours}:${minutes}`;
   }
 }

--- a/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
+++ b/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
@@ -35,12 +35,13 @@ const CSV_HEADERS = [
  * Format: YYYY-MM-DD HH:MM:SS (no T separator, no timezone)
  */
 function formatDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
+  // UTC readers so timestamps align with FireSTARR's --tz 0 ingest.
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
 
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }


### PR DESCRIPTION
## Summary

FireSTARR was being handed a UTC-read time labeled with a solar-longitude `--tz`, producing arrival-raster values several hours off from the user's configured ignition time. For a Hay River 13:00 MDT model, the raster's earliest arrival read as 05:08 MDT. Fix hands FireSTARR everything in UTC.

- `FireSTARREngine.buildCommand`: `utcOffset = 0` (was `Math.round(longitude/15) = -8`)
- `formatDate` / `formatTime` (engine) + `formatDate` (WeatherCSVWriter): switch to `getUTC*` readers so behaviour is stable regardless of server TZ

## Test plan

- [ ] Re-run a deterministic model on sulu (same params as `a1dc1d03`)
- [ ] Verify raster min arrival equals the configured `timeRange.start` in UTC
- [ ] Verify the animation's first frame renders at the ignition polygon
- [ ] Verify the Player time label matches the analyst's configured start time in local zone