### PR TITLE
fix(animation): drop ignition cells from frame 1

### DIFF
--- a/backend/src/infrastructure/firestarr/__tests__/arrivalAnimation.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/arrivalAnimation.test.ts
@@ -163,12 +163,13 @@ describe('buildReclassifyExpression', () => {
     expect(expr).toContain('A'); // input band
   });
 
-  it('clips pre-sim-start (pre-warmup) cells to DN=1 via numpy.maximum', () => {
-    // FireSTARR may emit arrival values earlier than timeRange.start during
-    // its warmup burn. Those cells must land in frame 1 (already-burning
-    // initial state), not be dropped as DN=0.
+  it('drops cells at or before simStart (they belong to the ignition layer, not the animation)', () => {
+    // The formula requires ceil((A-S)*24) >= 1, so a cell with A = simStart
+    // (ignition-polygon cell already burning at the sim start) produces
+    // DN=0 and is excluded by gdal_polygonize.
     const expr = buildReclassifyExpression(170.7917, 168);
-    expect(expr).toContain('maximum(1,');
+    expect(expr).toContain('>=1');
+    expect(expr).not.toContain('maximum(');
   });
 });
 

--- a/backend/src/infrastructure/firestarr/arrivalAnimation.ts
+++ b/backend/src/infrastructure/firestarr/arrivalAnimation.ts
@@ -221,11 +221,13 @@ export function julianToDate(julianDay: number, year: number): Date {
  * used by the animation.
  *
  *  - Unburned cells (A=0) emit 0 so gdal_polygonize drops them.
- *  - Cells with arrival before simStart (FireSTARR's pre-warmup burn period,
- *    typically several hours) are clipped to DN=1 and rendered as part of
- *    the animation's initial state. Dropping them creates a visible gap
- *    between the ignition polygon and the first animated ring (refs #236).
+ *  - Cells with arrival AT or before simStart (A <= simStart, including
+ *    ignition-polygon cells whose arrival equals simStart) emit 0 — those
+ *    cells are "already burning" and belong to the ignition layer, not the
+ *    animation. The frontend can show the user's ignition polygon
+ *    separately (refs #236).
  *  - Cells beyond the capFrames window emit 0.
+ *  - Everything in (simStart, simStart + capFrames*h] gets a 1-based DN.
  */
 export function buildReclassifyExpression(
   simStartJulian: number,
@@ -233,10 +235,7 @@ export function buildReclassifyExpression(
 ): string {
   const raw = `ceil((A-${simStartJulian})*24)`;
   return (
-    `((A>0)*` +
-    `(${raw}<=${capFrames})*` +
-    `maximum(1, ${raw}.astype(int))` +
-    `).astype(int)`
+    `((A>0)*(${raw}>=1)*(${raw}<=${capFrames})*${raw}).astype(int)`
   );
 }
 


### PR DESCRIPTION
After the UTC handoff fix, FireSTARR no longer emits pre-sim arrival values — rasterMin ≈ simStart. The old warmup-clip now rolls ignition cells (A = simStart) into frame 1, so the first ring swallows the whole ignition polygon. Switch back to a strict >=1 predicate so ignition cells drop out and frame 1 is only the genuine first-hour ring.