### PR TITLE
revert: firestarr UTC tz (PR #250) — breaks weather CSV lookup

### DIFF
--- a/backend/src/infrastructure/firestarr/FireSTARREngine.ts
+++ b/backend/src/infrastructure/firestarr/FireSTARREngine.ts
@@ -695,15 +695,9 @@ export class FireSTARREngine implements IFireModelingEngine {
       logger.debug(`Using corrected centroid: lat=${latitude.toFixed(6)}, lon=${longitude.toFixed(6)} (original: lat=${params.latitude.toFixed(6)}, lon=${params.longitude.toFixed(6)})`, 'FireSTARR');
     }
 
-    // Hand FireSTARR everything in UTC. The old longitude-based solar
-    // timezone approximation (round(longitude/15)) was wrong for two
-    // reasons: (1) it doesn't track real timezones (Hay River is MDT =
-    // UTC-6 in summer, not UTC-8 at longitude -115°), and (2) the
-    // date/time we pass alongside --tz comes from UTC-read getters,
-    // which already encodes the moment in UTC. Mixing a UTC time with a
-    // solar-TZ label caused arrival-raster values to drift by several
-    // hours (refs #236 debugging, 2026-04-23).
-    const utcOffset = 0;
+    // Calculate UTC offset from longitude (natural solar timezone)
+    // Each 15° of longitude = 1 hour offset from UTC
+    const utcOffset = Math.round(longitude / 15);
 
     const args: string[] = [
       binaryPath,
@@ -761,10 +755,9 @@ export class FireSTARREngine implements IFireModelingEngine {
    * Formats a date as yyyy-mm-dd.
    */
   private formatDate(date: Date): string {
-    // UTC readers so behaviour is identical regardless of server TZ.
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(date.getUTCDate()).padStart(2, '0');
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   }
 
@@ -772,9 +765,8 @@ export class FireSTARREngine implements IFireModelingEngine {
    * Formats a date's time as HH:MM.
    */
   private formatTime(date: Date): string {
-    // UTC readers so the time we hand FireSTARR matches the --tz 0 we pass.
-    const hours = String(date.getUTCHours()).padStart(2, '0');
-    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
     return `${hours}:${minutes}`;
   }
 }

--- a/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
+++ b/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
@@ -35,13 +35,12 @@ const CSV_HEADERS = [
  * Format: YYYY-MM-DD HH:MM:SS (no T separator, no timezone)
  */
 function formatDate(date: Date): string {
-  // UTC readers so timestamps align with FireSTARR's --tz 0 ingest.
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(date.getUTCDate()).padStart(2, '0');
-  const hours = String(date.getUTCHours()).padStart(2, '0');
-  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
-  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
 
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }


### PR DESCRIPTION
PR #250 changed FireSTARR's command-line tz from the solar-longitude approximation to `--tz 0` and switched the formatters to UTC. In practice FireSTARR treats `--tz 0` specially (internal sim start shifted by 1 h) and then can't reconcile its expected timestamps against the weather CSV (which carries user-local clock times). Sim fails with `FATAL: map::at: key not found` the moment FireSTARR opens weather.csv.

Revert restores the previous behaviour so models run again. Proper fix — plumb the user's IANA timezone through from the wizard to FireSTARREngine and use it consistently — is a separate follow-up.