### PR TITLE
fix(firestarr): IANA timezone wiring + animation/label corrections

### DIFF
--- a/backend/src/api/__tests__/timezoneValidation.test.ts
+++ b/backend/src/api/__tests__/timezoneValidation.test.ts
@@ -1,0 +1,59 @@
+/**
+ * /models/run timezone fail-fast validation
+ *
+ * The route MUST reject requests that omit `timezone`. No silent runtime-zone
+ * fallback (Papa's fail-fast policy + correctness with FireSTARR --tz).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import modelsRouter from '../routes/v1/models.js';
+
+describe('POST /models/run — timezone fail-fast', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    // Generic error handler so thrown ValidationErrors become JSON
+    app.use('/api/v1', modelsRouter);
+    app.use((err: Error & { httpStatus?: number; statusCode?: number; fieldErrors?: unknown }, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      res.status(err.httpStatus ?? err.statusCode ?? 500).json({
+        error: err.message,
+        fieldErrors: err.fieldErrors,
+      });
+    });
+  });
+
+  const validBodyMinusTimezone = {
+    name: 'TZ fail-fast test',
+    engineType: 'firestarr',
+    ignition: { type: 'point', coordinates: [-115.7, 60.82] },
+    timeRange: {
+      start: '2023-06-19T19:00:00Z',
+      end: '2023-06-22T19:00:00Z',
+    },
+    weather: { source: 'firestarr_csv' },
+    modelMode: 'deterministic',
+    // timezone intentionally omitted
+  };
+
+  it('returns 400 when timezone field is missing', async () => {
+    const res = await request(app)
+      .post('/api/v1/models/run')
+      .send(validBodyMinusTimezone);
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/timezone/i);
+  });
+
+  it('returns 400 when timezone is empty string', async () => {
+    const res = await request(app)
+      .post('/api/v1/models/run')
+      .send({ ...validBodyMinusTimezone, timezone: '' });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/timezone/i);
+  });
+});

--- a/backend/src/api/routes/v1/__tests__/importResponseConfig.test.ts
+++ b/backend/src/api/routes/v1/__tests__/importResponseConfig.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Import response config cherry-pick — defense-in-depth test.
+ *
+ * Re-run reads /models/:id/config (which sources from model.json) so this
+ * cherry-pick isn't on the critical path. But any UI consuming the import
+ * response config directly would inherit whichever fields we forward here.
+ * Keeping `timezone` in the list so future consumers don't repeat the
+ * regression that broke the Dashboard re-run handler.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pickImportResponseConfig } from '../importResponseConfig.js';
+
+describe('pickImportResponseConfig', () => {
+  it('forwards timezone alongside other re-runnable fields', () => {
+    const result = pickImportResponseConfig({
+      ignition: { type: 'point', coordinates: [-115.7, 60.82] },
+      timeRange: { start: '2023-06-19T19:00:00Z', end: '2023-06-22T19:00:00Z' },
+      weather: { source: 'firestarr_csv' },
+      timezone: 'America/Edmonton',
+      scenarios: 1,
+      modelMode: 'deterministic',
+      // unrelated noise that shouldn't be forwarded
+      internalState: 'should-not-leak',
+    });
+
+    expect(result.timezone).toBe('America/Edmonton');
+    expect(result.modelMode).toBe('deterministic');
+    expect((result as Record<string, unknown>).internalState).toBeUndefined();
+  });
+
+  it('returns timezone undefined when source config lacks it (older models)', () => {
+    const result = pickImportResponseConfig({
+      ignition: { type: 'point', coordinates: [0, 0] },
+      timeRange: { start: 'a', end: 'b' },
+      weather: { source: 'firestarr_csv' },
+    });
+    expect(result.timezone).toBeUndefined();
+  });
+});

--- a/backend/src/api/routes/v1/import.ts
+++ b/backend/src/api/routes/v1/import.ts
@@ -30,6 +30,7 @@ import {
   OutputFormat,
 } from '../../../domain/entities/ModelResult.js';
 import { getModelRepository, getResultRepository } from '../../../infrastructure/database/index.js';
+import { pickImportResponseConfig } from './importResponseConfig.js';
 
 const router = Router();
 
@@ -228,13 +229,7 @@ router.post(
       name: model.name,
       status: model.status,
       hasConfig: !!modelConfig,
-      config: modelConfig ? {
-        ignition: modelConfig.ignition,
-        timeRange: modelConfig.timeRange,
-        weather: modelConfig.weather,
-        scenarios: modelConfig.scenarios,
-        modelMode: modelConfig.modelMode,
-      } : null,
+      config: modelConfig ? pickImportResponseConfig(modelConfig as unknown as Record<string, unknown>) : null,
       imported: {
         files: importedFiles.length,
         results: resultRecords.length,

--- a/backend/src/api/routes/v1/importResponseConfig.ts
+++ b/backend/src/api/routes/v1/importResponseConfig.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure cherry-pick used by POST /api/v1/import to build the response `config`
+ * field. Kept tiny and exported so re-runnable fields stay in one place —
+ * adding a new field here flows to any consumer that reads the import
+ * response directly.
+ */
+
+export interface ImportResponseConfig {
+  ignition?: unknown;
+  timeRange?: unknown;
+  weather?: unknown;
+  scenarios?: number;
+  modelMode?: 'probabilistic' | 'deterministic';
+  timezone?: string;
+}
+
+export function pickImportResponseConfig(
+  source: Record<string, unknown>,
+): ImportResponseConfig {
+  return {
+    ignition: source.ignition,
+    timeRange: source.timeRange,
+    weather: source.weather,
+    scenarios: source.scenarios as number | undefined,
+    modelMode: source.modelMode as 'probabilistic' | 'deterministic' | undefined,
+    timezone: source.timezone as string | undefined,
+  };
+}

--- a/backend/src/api/routes/v1/models.ts
+++ b/backend/src/api/routes/v1/models.ts
@@ -47,6 +47,8 @@ interface RunModelRequestBody {
     start: string;
     end: string;
   };
+  /** IANA timezone identifier (e.g. "America/Edmonton"). Required — no fallback. */
+  timezone: string;
   weather: WeatherConfig;
   scenarios?: number;
   outputMode?: 'probabilistic' | 'deterministic';
@@ -129,6 +131,11 @@ router.post(
         { field: 'weather', message: 'Must provide weather source' },
       ]);
     }
+    if (typeof body.timezone !== 'string' || body.timezone.length === 0) {
+      throw new ValidationError('Timezone required', [
+        { field: 'timezone', message: 'Must provide IANA timezone identifier (e.g. "America/Edmonton") — no runtime fallback' },
+      ]);
+    }
 
     // Validate and resolve modelMode (default: probabilistic)
     const modelMode: ModelMode = body.modelMode ?? 'probabilistic';
@@ -197,6 +204,7 @@ router.post(
     const executionOptions: ExecutionOptions = {
       ignitionGeometry,
       timeRange,
+      timezone: body.timezone,
       weatherConfig: body.weather,
       simulationCount: body.scenarios ?? 100,
       outputMode: derivedOutputMode,
@@ -420,6 +428,8 @@ interface ExecuteRequestBody {
     start: string;
     end: string;
   };
+  /** IANA timezone identifier (e.g. "America/Edmonton"). Required — no fallback. */
+  timezone: string;
   weather: WeatherConfig;
   scenarios?: number;
   outputMode?: 'probabilistic' | 'deterministic';
@@ -565,6 +575,11 @@ router.post(
         { field: 'weather', message: 'Must provide weather source (manual or spotwx)' },
       ]);
     }
+    if (typeof body.timezone !== 'string' || body.timezone.length === 0) {
+      throw new ValidationError('Timezone required', [
+        { field: 'timezone', message: 'Must provide IANA timezone identifier (e.g. "America/Edmonton") — no runtime fallback' },
+      ]);
+    }
 
     // Create ignition geometry
     const geometryType = body.ignition.type === 'point'
@@ -589,6 +604,7 @@ router.post(
     const executionOptions: ExecutionOptions = {
       ignitionGeometry,
       timeRange,
+      timezone: body.timezone,
       weatherConfig: body.weather,
       simulationCount: body.scenarios ?? 100,
       outputMode: body.outputMode === 'deterministic' ? 'deterministic' : 'probabilistic',

--- a/backend/src/application/interfaces/IFireModelingEngine.ts
+++ b/backend/src/application/interfaces/IFireModelingEngine.ts
@@ -41,6 +41,8 @@ export interface ExecutionOptions {
   readonly ignitionGeometry: SpatialGeometry;
   /** Time range for the simulation */
   readonly timeRange: TimeRange;
+  /** IANA timezone identifier for ignition location (e.g. "America/Edmonton"). Required — no silent default. */
+  readonly timezone: string;
   /** Output time offsets in hours from start */
   readonly outputTimeOffsets?: number[];
   /** Probability threshold for perimeter generation (0-1) */

--- a/backend/src/application/services/ModelResultsService.ts
+++ b/backend/src/application/services/ModelResultsService.ts
@@ -285,9 +285,13 @@ export class ModelResultsService {
         // Get file path from metadata
         const filePath = (result.metadata.filePath as string) ?? null;
 
-        // Calculate time offset in hours from days
-        const julianDay = (result.metadata.parameters as Record<string, unknown>)?.julianDay as number | undefined;
-        const timeOffsetHours = julianDay !== undefined ? julianDay * 24 : null;
+        // Calculate time offset in hours from days.
+        // TODO(#236-followup): this used to be `julianDay * 24` which is
+        // year-anchored (e.g. Jun 19 → 4080h). The deterministic perimeter
+        // path below uses `(julianDay - startJulian) * 24` instead. This .map
+        // runs for stored DB results (probabilistic outputs) where startJulian
+        // is not yet in scope; null is safer than a misleading absolute value.
+        const timeOffsetHours: number | null = null;
 
         return {
           id: result.id,
@@ -388,6 +392,11 @@ export class ModelResultsService {
               // Check if perimeter outputs already exist
               const hasPerimeters = outputs.some(o => o.type === 'perimeter');
 
+              // Hoisted so the perimeter cherry-pick below can compute
+              // hours-since-simStart from each perimeter's filename julianDay.
+              // null when no arrival raster / timeRange is available.
+              let startJulianForPerimeters: number | null = null;
+
               // Arrival raster output (#226) — emit one OutputItem pointing at
               // the classified tile endpoint. Classification window is derived
               // from the model's configured timeRange, not from file count.
@@ -432,6 +441,7 @@ export class ModelResultsService {
                     } catch { /* use current year */ }
                     startDate = new Date(Date.UTC(modelYear, 0, startJulian)).toISOString();
                   }
+                  startJulianForPerimeters = startJulian;
 
                   outputs.push({
                     id: `arrival-time-${modelId}`,
@@ -472,12 +482,18 @@ export class ModelResultsService {
                   perimeterResult.value.perimeters.forEach((perimeter, index) => {
                     const dateLabel = perimeter.date || `Day ${perimeter.julianDay}`;
                     const color = PERIMETER_COLORS[index % PERIMETER_COLORS.length];
+                    // Hours since sim start, not "hours since Jan 1 of year 0".
+                    // perimeter.julianDay is the FILENAME's 1-indexed day-of-year
+                    // (170 = Jun 19), startJulian was computed from timeRange.start
+                    // above. For a 3-day sim starting Jun 19 these read 0, 24, 48.
                     outputs.push({
                       id: `perimeter-day${perimeter.julianDay}-${modelId}`,
                       type: 'perimeter' as OutputType,
                       format: 'geojson' as OutputFormat,
                       name: `Fire Boundary - ${dateLabel}`,
-                      timeOffsetHours: perimeter.julianDay * 24,
+                      timeOffsetHours: startJulianForPerimeters !== null
+                        ? (perimeter.julianDay - startJulianForPerimeters) * 24
+                        : null,
                       filePath: null,
                       previewUrl: `/api/v1/models/${modelId}/perimeters?day=${perimeter.julianDay}`,
                       downloadUrl: `/api/v1/models/${modelId}/perimeters?day=${perimeter.julianDay}&download=true`,

--- a/backend/src/infrastructure/firestarr/FireSTARREngine.ts
+++ b/backend/src/infrastructure/firestarr/FireSTARREngine.ts
@@ -26,6 +26,11 @@ import {
 } from '../../domain/entities/index.js';
 import { Coordinates } from '../../domain/value-objects/index.js';
 import { FireSTARRParams, WeatherHourlyData } from './types.js';
+import {
+  computeUtcOffsetHours,
+  formatLocalDate,
+  formatLocalTime,
+} from './timezoneUtils.js';
 import { getFireSTARRExecutor, isBinaryMode } from '../execution/index.js';
 import { FireSTARRInputGenerator, createFireSTARRInputGenerator } from './FireSTARRInputGenerator.js';
 import { FireSTARROutputParser, getFireSTARROutputParser } from './FireSTARROutputParser.js';
@@ -145,6 +150,7 @@ export class FireSTARREngine implements IFireModelingEngine {
         start: options.timeRange.start.toISOString(),
         end: options.timeRange.end.toISOString(),
       } : undefined,
+      timezone: options.timezone,
       weather: options.weatherConfig,
       modelMode: options.outputMode === 'deterministic' ? 'deterministic' : 'probabilistic',
     };
@@ -637,7 +643,8 @@ export class FireSTARREngine implements IFireModelingEngine {
       latitude,
       longitude,
       startDate,
-      startTime: this.formatTime(options.timeRange.start),
+      startTime: formatLocalTime(options.timeRange.start, options.timezone),
+      timezone: options.timezone,
       weatherData,
       previousFFMC: firstPoint.ffmc,
       previousDMC: firstPoint.dmc,
@@ -695,14 +702,14 @@ export class FireSTARREngine implements IFireModelingEngine {
       logger.debug(`Using corrected centroid: lat=${latitude.toFixed(6)}, lon=${longitude.toFixed(6)} (original: lat=${params.latitude.toFixed(6)}, lon=${params.longitude.toFixed(6)})`, 'FireSTARR');
     }
 
-    // Calculate UTC offset from longitude (natural solar timezone)
-    // Each 15° of longitude = 1 hour offset from UTC
-    const utcOffset = Math.round(longitude / 15);
+    // UTC offset comes from the caller's IANA zone (DST-aware), not solar
+    // longitude. Hay River sits at -115° but observes MDT/MST.
+    const utcOffset = computeUtcOffsetHours(params.startDate, params.timezone);
 
     const args: string[] = [
       binaryPath,
       workingDir,
-      this.formatDate(params.startDate),
+      formatLocalDate(params.startDate, params.timezone),
       latitude.toString(),
       longitude.toString(),
       params.startTime,
@@ -751,24 +758,6 @@ export class FireSTARREngine implements IFireModelingEngine {
     return args;
   }
 
-  /**
-   * Formats a date as yyyy-mm-dd.
-   */
-  private formatDate(date: Date): string {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  }
-
-  /**
-   * Formats a date's time as HH:MM.
-   */
-  private formatTime(date: Date): string {
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
-    return `${hours}:${minutes}`;
-  }
 }
 
 /**

--- a/backend/src/infrastructure/firestarr/FireSTARRInputGenerator.ts
+++ b/backend/src/infrastructure/firestarr/FireSTARRInputGenerator.ts
@@ -188,6 +188,7 @@ export class FireSTARRInputGenerator implements IInputGenerator<FireSTARRParams>
       const weatherFile = join(workingDir, 'weather.csv');
       await writeWeatherCSV(weatherFile, params.weatherData, {
         scenarioId: params.scenarioId ?? 0,
+        timezone: params.timezone,
       });
 
       // Write ignition geometry as GeoJSON Feature

--- a/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
+++ b/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
@@ -9,6 +9,7 @@
 
 import { writeFile } from 'fs/promises';
 import { WeatherHourlyData } from './types.js';
+import { formatLocalDateTime } from './timezoneUtils.js';
 
 /**
  * CSV column headers in required order.
@@ -31,21 +32,6 @@ const CSV_HEADERS = [
 ] as const;
 
 /**
- * Formats a date for FireSTARR CSV.
- * Format: YYYY-MM-DD HH:MM:SS (no T separator, no timezone)
- */
-function formatDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
-
-  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
-}
-
-/**
  * Formats a number for CSV output.
  * Uses up to 2 decimal places, removes trailing zeros.
  */
@@ -56,10 +42,10 @@ function formatNumber(value: number): string {
 /**
  * Converts weather data to a CSV row.
  */
-function weatherToRow(weather: WeatherHourlyData, scenarioId: number): string {
+function weatherToRow(weather: WeatherHourlyData, scenarioId: number, timezone: string): string {
   const values = [
     scenarioId.toString(),
-    formatDate(weather.date),
+    formatLocalDateTime(weather.date, timezone),
     formatNumber(weather.precip),
     formatNumber(weather.temp),
     formatNumber(weather.rh),
@@ -82,6 +68,8 @@ function weatherToRow(weather: WeatherHourlyData, scenarioId: number): string {
 export interface WeatherCSVOptions {
   /** Scenario ID (default: 0 for deterministic runs) */
   scenarioId?: number;
+  /** IANA timezone identifier for CSV timestamps. Required — must match engine `--tz`. */
+  timezone: string;
 }
 
 /**
@@ -102,14 +90,21 @@ export interface WeatherCSVOptions {
 export async function writeWeatherCSV(
   filePath: string,
   weatherData: WeatherHourlyData[],
-  options: WeatherCSVOptions = {}
+  options: WeatherCSVOptions
 ): Promise<void> {
+  if (typeof options?.timezone !== 'string' || options.timezone.length === 0) {
+    throw new Error(
+      'WeatherCSVWriter: IANA timezone is required (no runtime-zone fallback). ' +
+      'Caller must pass options.timezone matching the engine --tz value.',
+    );
+  }
   const scenarioId = options.scenarioId ?? 0;
+  const timezone = options.timezone;
 
   // Build CSV content
   const lines: string[] = [
     CSV_HEADERS.join(','),
-    ...weatherData.map((w) => weatherToRow(w, scenarioId)),
+    ...weatherData.map((w) => weatherToRow(w, scenarioId, timezone)),
   ];
 
   const content = lines.join('\n') + '\n';

--- a/backend/src/infrastructure/firestarr/__tests__/FireSTARREngine.rerun.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/FireSTARREngine.rerun.test.ts
@@ -69,6 +69,7 @@ describe('FireSTARREngine — output-config.json for re-run', () => {
       new Date('2026-07-01T12:00:00Z'),
       new Date('2026-07-04T12:00:00Z'),
     ),
+    timezone: 'America/Edmonton',
     weatherConfig: {
       source: 'firestarr_csv' as const,
     },

--- a/backend/src/infrastructure/firestarr/__tests__/FireSTARREngine.timezone.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/FireSTARREngine.timezone.test.ts
@@ -1,0 +1,205 @@
+/**
+ * FireSTARREngine — IANA timezone wiring (refs #236 follow-up)
+ *
+ * Asserts the CLI command emits `--tz` based on the caller's IANA zone, not
+ * a solar-longitude approximation. Hay River sits at ~-115.7° but observes
+ * Mountain Time (DST). Solar gives -8; reality is -6 in summer, -7 in winter.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, mkdir, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { FireSTARREngine } from '../FireSTARREngine.js';
+import {
+  FireModel,
+  createFireModelId,
+  EngineType,
+  ModelStatus,
+  GeometryType,
+  SpatialGeometry,
+} from '../../../domain/entities/index.js';
+import { TimeRange } from '../../../domain/value-objects/index.js';
+import type { ExecutionOptions } from '../../../application/interfaces/IFireModelingEngine.js';
+import type { IContainerExecutor, ContainerRunOptions } from '../../../application/interfaces/IContainerExecutor.js';
+import type { IInputGenerator, InputGenerationResult } from '../../../application/interfaces/IInputGenerator.js';
+import type { IOutputParser, ParsedOutput } from '../../../application/interfaces/IOutputParser.js';
+import type { FireSTARRParams } from '../types.js';
+import { Result } from '../../../application/common/index.js';
+
+interface CapturedCommand {
+  args: string[];
+}
+
+function createCapturingExecutor(captured: CapturedCommand[]): IContainerExecutor {
+  return {
+    run: vi.fn(),
+    runStream: vi.fn().mockImplementation(async (options: ContainerRunOptions) => {
+      captured.push({ args: [...options.command] });
+      return Result.ok({ exitCode: 0, stdout: '', stderr: '', durationMs: 1 });
+    }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    isServiceAvailable: vi.fn().mockResolvedValue(true),
+  } as unknown as IContainerExecutor;
+}
+
+function createMockOutputParser(): IOutputParser<ParsedOutput[]> {
+  return {
+    parse: vi.fn().mockResolvedValue(Result.ok([])),
+    parseLog: vi.fn().mockResolvedValue({ success: true, durationSeconds: 1 }),
+  } as unknown as IOutputParser<ParsedOutput[]>;
+}
+
+/** Pull the value following a flag from the captured args list. */
+function flagValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+describe('FireSTARREngine — IANA timezone in buildCommand', () => {
+  let tempDir: string;
+  let workingDir: string;
+  let captured: CapturedCommand[];
+  let engine: FireSTARREngine;
+  let mockInputGenerator: IInputGenerator<FireSTARRParams>;
+
+  // Hay River, NWT — uses MDT (America/Edmonton) but sits at ~-115.7°.
+  // Solar approximation gives -8; correct answer is -6 summer / -7 winter.
+  const hayRiverIgnition = new SpatialGeometry({
+    type: GeometryType.Point,
+    coordinates: [-115.7, 60.82],
+  });
+
+  const baseWeather = (year: number, month: number, day: number) => [{
+    datetime: new Date(Date.UTC(year, month - 1, day, 19, 0, 0)),
+    temperature: 22,
+    humidity: 35,
+    windSpeed: 12,
+    windDirection: 230,
+    precipitation: 0,
+    ffmc: 88,
+    dmc: 35,
+    dc: 280,
+  }];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'firestarr-tz-test-'));
+    workingDir = join(tempDir, 'sims', 'tz-test-model');
+    await mkdir(workingDir, { recursive: true });
+
+    captured = [];
+
+    mockInputGenerator = {
+      generate: vi.fn().mockResolvedValue(Result.ok({
+        workingDir,
+        weatherFile: join(workingDir, 'weather.csv'),
+        configFiles: [],
+      } as InputGenerationResult)),
+      cleanup: vi.fn(),
+    } as unknown as IInputGenerator<FireSTARRParams>;
+
+    engine = new FireSTARREngine(
+      createCapturingExecutor(captured),
+      mockInputGenerator,
+      createMockOutputParser(),
+    );
+
+    // Force binary mode so workingDir resolution doesn't traverse Docker paths
+    process.env.FIRESTARR_EXECUTION_MODE = 'binary';
+    process.env.FIRESTARR_BINARY_PATH = '/usr/local/bin/firestarr';
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    delete process.env.FIRESTARR_EXECUTION_MODE;
+    delete process.env.FIRESTARR_BINARY_PATH;
+  });
+
+  it('emits --tz -6 for Hay River summer ignition (America/Edmonton, DST)', async () => {
+    const modelId = createFireModelId('tz-summer');
+    const model = new FireModel({
+      id: modelId,
+      name: 'TZ summer test',
+      engineType: EngineType.FireSTARR,
+      status: ModelStatus.Queued,
+      userId: 'test-user',
+    });
+
+    const summerOptions: ExecutionOptions = {
+      ignitionGeometry: hayRiverIgnition,
+      timeRange: new TimeRange(
+        new Date('2023-06-19T19:00:00Z'), // 13:00 MDT
+        new Date('2023-06-22T19:00:00Z'),
+      ),
+      timezone: 'America/Edmonton',
+      weatherData: baseWeather(2023, 6, 19),
+      outputMode: 'deterministic',
+    };
+
+    await engine.initialize(model, summerOptions);
+    await engine.execute(modelId);
+
+    expect(captured.length).toBeGreaterThan(0);
+    expect(flagValue(captured[0].args, '--tz')).toBe('-6');
+  });
+
+  it('emits --tz -7 for Hay River winter ignition (America/Edmonton, standard time)', async () => {
+    const modelId = createFireModelId('tz-winter');
+    const model = new FireModel({
+      id: modelId,
+      name: 'TZ winter test',
+      engineType: EngineType.FireSTARR,
+      status: ModelStatus.Queued,
+      userId: 'test-user',
+    });
+
+    const winterOptions: ExecutionOptions = {
+      ignitionGeometry: hayRiverIgnition,
+      timeRange: new TimeRange(
+        new Date('2023-01-15T20:00:00Z'), // 13:00 MST
+        new Date('2023-01-18T20:00:00Z'),
+      ),
+      timezone: 'America/Edmonton',
+      weatherData: baseWeather(2023, 1, 15),
+      outputMode: 'deterministic',
+    };
+
+    await engine.initialize(model, winterOptions);
+    await engine.execute(modelId);
+
+    expect(flagValue(captured[0].args, '--tz')).toBe('-7');
+  });
+
+  it('emits start-of-command date and time in caller-local zone', async () => {
+    const modelId = createFireModelId('tz-walltime');
+    const model = new FireModel({
+      id: modelId,
+      name: 'TZ wall-time test',
+      engineType: EngineType.FireSTARR,
+      status: ModelStatus.Queued,
+      userId: 'test-user',
+    });
+
+    const options: ExecutionOptions = {
+      ignitionGeometry: hayRiverIgnition,
+      timeRange: new TimeRange(
+        new Date('2023-06-19T19:00:00Z'), // 13:00 MDT
+        new Date('2023-06-22T19:00:00Z'),
+      ),
+      timezone: 'America/Edmonton',
+      weatherData: baseWeather(2023, 6, 19),
+      outputMode: 'deterministic',
+    };
+
+    await engine.initialize(model, options);
+    await engine.execute(modelId);
+
+    // Command positional args after binary + workingDir: date, lat, lon, time
+    const args = captured[0].args;
+    // Find date by looking for a YYYY-MM-DD shape early in the args
+    const date = args.find((a) => /^\d{4}-\d{2}-\d{2}$/.test(a));
+    const time = args.find((a) => /^\d{2}:\d{2}$/.test(a));
+    expect(date).toBe('2023-06-19');
+    expect(time).toBe('13:00');
+  });
+});

--- a/backend/src/infrastructure/firestarr/__tests__/WeatherCSVWriter.timezone.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/WeatherCSVWriter.timezone.test.ts
@@ -1,0 +1,65 @@
+/**
+ * WeatherCSVWriter — IANA timezone in CSV timestamps
+ *
+ * FireSTARR matches weather rows by string equality on the local-clock
+ * timestamp. The CSV must therefore agree with the engine's `--tz` and the
+ * caller's IANA zone, not the server's runtime zone.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { writeWeatherCSV } from '../WeatherCSVWriter.js';
+import type { WeatherHourlyData } from '../types.js';
+
+describe('writeWeatherCSV — IANA timezone formatting', () => {
+  let tempDir: string;
+  let csvPath: string;
+
+  const sampleHour: WeatherHourlyData = {
+    date: new Date('2023-06-19T19:00:00Z'), // 13:00 MDT, 04:00 next-day Tokyo
+    temp: 22,
+    rh: 35,
+    ws: 12,
+    wd: 230,
+    precip: 0,
+    ffmc: 88,
+    dmc: 35,
+    dc: 280,
+    isi: 4,
+    bui: 50,
+    fwi: 12,
+  };
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'wxcsv-tz-'));
+    csvPath = join(tempDir, 'weather.csv');
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('formats CSV Date column in caller-supplied IANA timezone (Asia/Tokyo)', async () => {
+    await writeWeatherCSV(csvPath, [sampleHour], { timezone: 'Asia/Tokyo' });
+    const content = await readFile(csvPath, 'utf-8');
+    const dataRow = content.split('\n')[1];
+    // 2023-06-19 19:00 UTC == 2023-06-20 04:00 Tokyo
+    expect(dataRow.split(',')[1]).toBe('2023-06-20 04:00:00');
+  });
+
+  it('formats CSV Date column in America/Edmonton (DST → -6)', async () => {
+    await writeWeatherCSV(csvPath, [sampleHour], { timezone: 'America/Edmonton' });
+    const content = await readFile(csvPath, 'utf-8');
+    const dataRow = content.split('\n')[1];
+    expect(dataRow.split(',')[1]).toBe('2023-06-19 13:00:00');
+  });
+
+  it('throws when timezone is not supplied (fail-fast, no runtime fallback)', async () => {
+    await expect(
+      // @ts-expect-error — we want to prove the runtime guard, even with type bypass
+      writeWeatherCSV(csvPath, [sampleHour], {}),
+    ).rejects.toThrow(/timezone is required/i);
+  });
+});

--- a/backend/src/infrastructure/firestarr/__tests__/arrivalAnimation.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/arrivalAnimation.test.ts
@@ -15,6 +15,7 @@ import {
   julianDayFromDate,
   julianToDate,
   toAnimationFeatureCollection,
+  toFireSTARRRasterJulianDay,
 } from '../arrivalAnimation.js';
 
 describe('computeAnimationFrames', () => {
@@ -120,6 +121,17 @@ describe('toAnimationFeatureCollection', () => {
       type: 'Polygon',
       coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
     });
+  });
+});
+
+describe('toFireSTARRRasterJulianDay', () => {
+  it('returns julianDayFromDate minus 1 (FireSTARR rasters use 0-indexed Julian)', () => {
+    // Hay River simStart from the Apr 25 2026 regression: raster max for the
+    // simStart pixel was empirically 169.79167. Our julianDayFromDate would
+    // give 170.79167, so the converter must subtract exactly 1.0.
+    const simStart = new Date('2023-06-19T19:00:00Z');
+    expect(julianDayFromDate(simStart)).toBeCloseTo(170.79167, 4);
+    expect(toFireSTARRRasterJulianDay(simStart)).toBeCloseTo(169.79167, 4);
   });
 });
 
@@ -259,7 +271,7 @@ describe('extractArrivalAnimation (orchestrator)', () => {
     expect(result.features[0].properties.isoTime).toBe('2026-06-19T22:00:00.000Z');
   });
 
-  it('passes the params.simStart julian day into the gdal_calc expression', async () => {
+  it('passes the FireSTARR-convention (0-indexed) sim start julian day into gdal_calc', async () => {
     const { deps, execCalls } = stubDeps();
 
     await extractArrivalAnimation(
@@ -271,9 +283,14 @@ describe('extractArrivalAnimation (orchestrator)', () => {
       deps,
     );
 
-    // julianDayFromDate(2023-06-19T19:00Z) = 170.7917
+    // Our julianDayFromDate(2023-06-19T19:00Z) = 170.7917 (Jan 1 = 1.0).
+    // FireSTARR writes 0-indexed values (Jan 1 = 0.0) inside the raster,
+    // so the value baked into the gdal_calc expression must be 169.7917.
+    // If we pass 170.7917 here, the first 24h of spread would be DN <= 0
+    // and dropped from the animation (regression observed Apr 25 2026).
     const calcCall = execCalls[0];
-    expect(calcCall).toContain('170.79');
+    expect(calcCall).toContain('169.79');
+    expect(calcCall).not.toContain('170.79');
   });
 
   it('cleans up the temp directory even when a command fails', async () => {

--- a/backend/src/infrastructure/firestarr/__tests__/arrivalAnimation.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/arrivalAnimation.test.ts
@@ -175,13 +175,18 @@ describe('buildReclassifyExpression', () => {
     expect(expr).toContain('A'); // input band
   });
 
-  it('drops cells at or before simStart (they belong to the ignition layer, not the animation)', () => {
-    // The formula requires ceil((A-S)*24) >= 1, so a cell with A = simStart
-    // (ignition-polygon cell already burning at the sim start) produces
-    // DN=0 and is excluded by gdal_polygonize.
+  it('clamps pre-warmup cells (A <= simStart, A > 0) into frame 1 instead of dropping', () => {
+    // FireSTARR emits arrival values for warmup growth that lands outside
+    // the user's ignition polygon BEFORE the user's simStart. PR #251 had
+    // dropped them, but Papa observed (Apr 26 2026) that the resulting
+    // animation skipped the visible "halo" of initial growth. The expression
+    // must clamp these into DN=1 (initial state) rather than dropping them.
     const expr = buildReclassifyExpression(170.7917, 168);
-    expect(expr).toContain('>=1');
-    expect(expr).not.toContain('maximum(');
+    expect(expr).toContain('maximum(');
+    // Must still gate on A>0 so true NoData (unburned) cells stay dropped.
+    expect(expr).toContain('A>0');
+    // The cap must still bound the upper end.
+    expect(expr).toContain('168');
   });
 });
 

--- a/backend/src/infrastructure/firestarr/__tests__/timezoneUtils.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/timezoneUtils.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for IANA timezone helpers used when handing data to FireSTARR
+ * (refs #236 follow-up, Apr 2026).
+ *
+ * FireSTARR is fed `--tz <hours>` along with wall-clock time strings and a
+ * weather CSV whose rows carry local timestamps. All three must agree on
+ * the same real-world local zone. Solar-longitude approximations and
+ * UTC-everywhere both fail in practice, so the user's IANA zone
+ * (e.g. `America/Edmonton`) is the single source of truth.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeUtcOffsetHours,
+  formatLocalDate,
+  formatLocalTime,
+  formatLocalDateTime,
+} from '../timezoneUtils.js';
+
+describe('computeUtcOffsetHours', () => {
+  it('returns -6 for America/Edmonton in summer (MDT)', () => {
+    const summer = new Date('2023-06-19T19:00:00Z');
+    expect(computeUtcOffsetHours(summer, 'America/Edmonton')).toBe(-6);
+  });
+
+  it('returns -7 for America/Edmonton in winter (MST)', () => {
+    const winter = new Date('2023-01-15T12:00:00Z');
+    expect(computeUtcOffsetHours(winter, 'America/Edmonton')).toBe(-7);
+  });
+
+  it('returns 0 for UTC', () => {
+    expect(computeUtcOffsetHours(new Date('2023-06-19T19:00:00Z'), 'UTC')).toBe(0);
+  });
+
+  it('throws on an unrecognised timezone rather than silently defaulting', () => {
+    expect(() =>
+      computeUtcOffsetHours(new Date('2023-06-19T19:00:00Z'), 'Not/A_Zone'),
+    ).toThrow(/timezone/i);
+  });
+});
+
+describe('formatLocalDate', () => {
+  it('renders the calendar date in the given zone', () => {
+    // 2023-06-19T19:00Z is 2023-06-19 13:00 in America/Edmonton.
+    expect(formatLocalDate(new Date('2023-06-19T19:00:00Z'), 'America/Edmonton')).toBe(
+      '2023-06-19',
+    );
+  });
+
+  it('handles day rollovers near midnight correctly', () => {
+    // 2023-06-20T05:00Z is 2023-06-19 23:00 MDT (Edmonton is UTC-6).
+    expect(formatLocalDate(new Date('2023-06-20T05:00:00Z'), 'America/Edmonton')).toBe(
+      '2023-06-19',
+    );
+  });
+});
+
+describe('formatLocalTime', () => {
+  it('renders HH:MM in the given zone with 24-hour clock', () => {
+    expect(formatLocalTime(new Date('2023-06-19T19:00:00Z'), 'America/Edmonton')).toBe(
+      '13:00',
+    );
+  });
+
+  it('pads single-digit hours', () => {
+    expect(formatLocalTime(new Date('2023-06-19T14:05:00Z'), 'America/Edmonton')).toBe(
+      '08:05',
+    );
+  });
+});
+
+describe('formatLocalDateTime', () => {
+  it('renders YYYY-MM-DD HH:MM:SS in the given zone', () => {
+    expect(
+      formatLocalDateTime(new Date('2023-06-19T19:00:00Z'), 'America/Edmonton'),
+    ).toBe('2023-06-19 13:00:00');
+  });
+});

--- a/backend/src/infrastructure/firestarr/arrivalAnimation.ts
+++ b/backend/src/infrastructure/firestarr/arrivalAnimation.ts
@@ -114,11 +114,13 @@ export async function extractArrivalAnimation(
     const geojsonPath = `${tmpDir}/frames.geojson`;
 
     // Anchor the reclassify to the user-configured sim start (from
-    // output-config.json's timeRange.start). FireSTARR may emit arrival
-    // values BEFORE this instant (pre-warmup), and the reclassify
-    // expression clips those to DN=1 so they become part of the
-    // animation's initial state rather than being dropped (refs #236).
-    const simStartJulian = julianDayFromDate(params.simStart);
+    // output-config.json's timeRange.start). FireSTARR writes arrival
+    // values in 0-indexed Julian days (Jan 1 = 0.0) inside the raster,
+    // so we MUST convert our 1-indexed simStart through
+    // toFireSTARRRasterJulianDay — otherwise gdal_calc compares against
+    // a value 24h ahead and the first day of spread gets bucketed as
+    // DN <= 0 and dropped (refs #236 follow-up).
+    const simStartJulian = toFireSTARRRasterJulianDay(params.simStart);
     const expression = buildReclassifyExpression(simStartJulian, capFrames);
 
     deps.exec(
@@ -197,13 +199,34 @@ export const DEFAULT_FRAME_CAP = 168;
 
 /**
  * Returns the day-of-year (Jan 1 = 1.0) for the given Date, including
- * fractional hours. This matches the convention FireSTARR uses in the
- * arrival-time raster (e.g., `170.464` = day 170 at ~11am UTC).
+ * fractional hours. This is the human/calendar convention (Jun 19 → 170).
+ *
+ * NOTE: FireSTARR writes a DIFFERENT convention inside the arrival-time
+ * raster — values are 0-indexed (Jan 1 = 0.0, so Jun 19 → 169.x).
+ * Use `toFireSTARRRasterJulianDay` when comparing this value against raster
+ * pixel values. The filename of an arrival raster (e.g. `..._170_arrival.tif`)
+ * still uses the 1-indexed convention this function returns.
  */
 export function julianDayFromDate(date: Date): number {
   const year = date.getUTCFullYear();
   const yearStartMs = Date.UTC(year, 0, 1, 0, 0, 0, 0);
   return 1 + (date.getTime() - yearStartMs) / 86_400_000;
+}
+
+/**
+ * Converts our 1-indexed `julianDayFromDate` into FireSTARR's 0-indexed
+ * raster-internal Julian day. FireSTARR writes Jan 1 00:00 UTC as 0.0 in
+ * arrival rasters; our convention writes it as 1.0. The two are off by
+ * exactly one day. Use this when feeding a date into `buildReclassifyExpression`
+ * or otherwise comparing against raster pixel values.
+ *
+ * Empirical proof (Hay River sim, simStart 2023-06-19 19:00 UTC):
+ *   julianDayFromDate(simStart) = 170.79167
+ *   raster value at simStart pixel = 169.79167  ← FireSTARR's convention
+ *   delta = exactly 1.0
+ */
+export function toFireSTARRRasterJulianDay(date: Date): number {
+  return julianDayFromDate(date) - 1;
 }
 
 /**

--- a/backend/src/infrastructure/firestarr/arrivalAnimation.ts
+++ b/backend/src/infrastructure/firestarr/arrivalAnimation.ts
@@ -243,22 +243,24 @@ export function julianToDate(julianDay: number, year: number): Date {
  * (band A, decimal Julian days) into a per-pixel frame index (1..capFrames)
  * used by the animation.
  *
- *  - Unburned cells (A=0) emit 0 so gdal_polygonize drops them.
- *  - Cells with arrival AT or before simStart (A <= simStart, including
- *    ignition-polygon cells whose arrival equals simStart) emit 0 — those
- *    cells are "already burning" and belong to the ignition layer, not the
- *    animation. The frontend can show the user's ignition polygon
- *    separately (refs #236).
+ *  - Unburned cells (A=0) emit 0 so gdal_polygonize drops them (NoData).
+ *  - Cells with A > 0 but arrival AT or before simStart (warmup growth
+ *    around the ignition polygon, plus the ignition cells themselves) are
+ *    CLAMPED into frame 1 — they belong to the animation's initial state.
+ *    Apr 26 2026: previously dropped by PR #251, which left a visible "halo"
+ *    of FireSTARR-side warmup growth missing from the slider's first frame.
  *  - Cells beyond the capFrames window emit 0.
- *  - Everything in (simStart, simStart + capFrames*h] gets a 1-based DN.
+ *  - Cells in (simStart, simStart + capFrames*h] get a 1-based DN.
  */
 export function buildReclassifyExpression(
   simStartJulian: number,
   capFrames: number,
 ): string {
   const raw = `ceil((A-${simStartJulian})*24)`;
+  // Clamp to >=1 so pre-warmup cells become DN=1 instead of being dropped.
+  const clamped = `maximum(${raw},1)`;
   return (
-    `((A>0)*(${raw}>=1)*(${raw}<=${capFrames})*${raw}).astype(int)`
+    `((A>0)*(${clamped}<=${capFrames})*${clamped}).astype(int)`
   );
 }
 

--- a/backend/src/infrastructure/firestarr/timezoneUtils.ts
+++ b/backend/src/infrastructure/firestarr/timezoneUtils.ts
@@ -1,0 +1,87 @@
+/**
+ * IANA timezone helpers for handing consistent local-time data to FireSTARR
+ * (refs #236 Apr 2026 follow-up).
+ *
+ * FireSTARR expects its command-line time, `--tz <hours>` value, and weather
+ * CSV timestamps to all agree on a single local zone. Solar-longitude
+ * approximations are wrong near real timezone boundaries (Hay River is MDT
+ * despite sitting at ~115°W ≈ solar UTC-8), and UTC-everywhere causes the
+ * binary to mis-handle DST regions. The only correct anchor is the user's
+ * IANA zone (from `data.temporal.timezone`).
+ */
+
+const NUMERIC_PARTS = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+} as const;
+
+function partsIn(date: Date, timezone: string): Record<string, string> {
+  let formatter: Intl.DateTimeFormat;
+  try {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      ...NUMERIC_PARTS,
+    });
+  } catch (err) {
+    throw new Error(`Invalid IANA timezone "${timezone}": ${(err as Error).message}`);
+  }
+  const parts = formatter.formatToParts(date);
+  const map: Record<string, string> = {};
+  for (const p of parts) {
+    if (p.type !== 'literal') map[p.type] = p.value;
+  }
+  // Intl may emit "24" for midnight in some runtimes; normalise to "00".
+  if (map.hour === '24') map.hour = '00';
+  return map;
+}
+
+/**
+ * Returns the UTC offset in hours for `date` in the given IANA timezone,
+ * accounting for DST (e.g. America/Edmonton returns -6 in summer, -7 in
+ * winter). Throws when the timezone name is not recognised so callers never
+ * silently fall back to UTC.
+ */
+export function computeUtcOffsetHours(date: Date, timezone: string): number {
+  const parts = partsIn(date, timezone);
+  const localAsUtcMs = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  return (localAsUtcMs - date.getTime()) / 3_600_000;
+}
+
+/**
+ * Returns the calendar date (`YYYY-MM-DD`) that `date` falls on in the given
+ * IANA timezone.
+ */
+export function formatLocalDate(date: Date, timezone: string): string {
+  const parts = partsIn(date, timezone);
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+/**
+ * Returns the wall-clock time (`HH:MM`) that `date` falls on in the given
+ * IANA timezone. 24-hour clock, zero-padded.
+ */
+export function formatLocalTime(date: Date, timezone: string): string {
+  const parts = partsIn(date, timezone);
+  return `${parts.hour}:${parts.minute}`;
+}
+
+/**
+ * Returns the wall-clock datetime (`YYYY-MM-DD HH:MM:SS`) that `date` falls on
+ * in the given IANA timezone. Used when writing weather CSV rows.
+ */
+export function formatLocalDateTime(date: Date, timezone: string): string {
+  const parts = partsIn(date, timezone);
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}:${parts.second}`;
+}

--- a/backend/src/infrastructure/firestarr/timezoneUtils.ts
+++ b/backend/src/infrastructure/firestarr/timezoneUtils.ts
@@ -21,6 +21,12 @@ const NUMERIC_PARTS = {
 } as const;
 
 function partsIn(date: Date, timezone: string): Record<string, string> {
+  if (typeof timezone !== 'string' || timezone.length === 0) {
+    throw new Error(
+      `IANA timezone is required (got ${JSON.stringify(timezone)}). ` +
+      'No silent fallback to runtime zone — caller must supply data.temporal.timezone.',
+    );
+  }
   let formatter: Intl.DateTimeFormat;
   try {
     formatter = new Intl.DateTimeFormat('en-US', {

--- a/backend/src/infrastructure/firestarr/types.ts
+++ b/backend/src/infrastructure/firestarr/types.ts
@@ -52,8 +52,10 @@ export interface FireSTARRParams {
   readonly longitude: number;
   /** Simulation start date */
   readonly startDate: Date;
-  /** Simulation start time (HH:MM format, local solar time) */
+  /** Simulation start time (HH:MM format, local wall-clock time in `timezone`) */
   readonly startTime: string;
+  /** IANA timezone identifier for ignition location (e.g. "America/Edmonton") */
+  readonly timezone: string;
   /** Hourly weather data array */
   readonly weatherData: WeatherHourlyData[];
   /** Previous day's FFMC (Fine Fuel Moisture Code) */

--- a/backend/src/mcp/__tests__/integration.test.ts
+++ b/backend/src/mcp/__tests__/integration.test.ts
@@ -182,6 +182,7 @@ describe('MCP Server Integration', () => {
           modelId,
           startTime: '2026-06-15T14:00:00Z',
           endTime: '2026-06-15T20:00:00Z',
+          timezone: 'America/Edmonton',
         },
       });
       expect(timeResult.isError).toBeFalsy();

--- a/backend/src/mcp/__tests__/tools/execution.test.ts
+++ b/backend/src/mcp/__tests__/tools/execution.test.ts
@@ -140,6 +140,7 @@ describe('MCP Execution Tools', () => {
         modelId,
         startTime: '2026-06-15T14:00:00Z',
         endTime: '2026-06-15T20:00:00Z',
+        timezone: 'America/Edmonton',
       },
     });
 

--- a/backend/src/mcp/__tests__/tools/models.test.ts
+++ b/backend/src/mcp/__tests__/tools/models.test.ts
@@ -383,6 +383,7 @@ describe('MCP Model Tools', () => {
           modelId,
           startTime: '2026-06-15T14:00:00Z',
           endTime: '2026-06-15T20:00:00Z',
+          timezone: 'America/Edmonton',
         },
       });
 
@@ -390,9 +391,11 @@ describe('MCP Model Tools', () => {
       const data = JSON.parse((result.content as Array<{ text: string }>)[0].text);
       expect(data.timeRange.start).toBe('2026-06-15T14:00:00Z');
       expect(data.timeRange.end).toBe('2026-06-15T20:00:00Z');
+      expect(data.timezone).toBe('America/Edmonton');
 
       const config = mockConfigs.get(modelId);
       expect(config?.timeRange).toEqual({ start: '2026-06-15T14:00:00Z', end: '2026-06-15T20:00:00Z' });
+      expect(config?.timezone).toBe('America/Edmonton');
     });
 
     it('rejects invalid startTime', async () => {
@@ -408,6 +411,7 @@ describe('MCP Model Tools', () => {
           modelId,
           startTime: 'not-a-date',
           endTime: '2026-06-15T20:00:00Z',
+          timezone: 'America/Edmonton',
         },
       });
 
@@ -430,6 +434,7 @@ describe('MCP Model Tools', () => {
           modelId,
           startTime: '2026-06-15T20:00:00Z',
           endTime: '2026-06-15T14:00:00Z', // before start
+          timezone: 'America/Edmonton',
         },
       });
 

--- a/backend/src/mcp/tools/execution.ts
+++ b/backend/src/mcp/tools/execution.ts
@@ -58,6 +58,7 @@ export function registerExecutionTools(server: McpServer): void {
       if (!config?.ignition) missing.push('ignition');
       if (!config?.weather) missing.push('weather');
       if (!config?.timeRange) missing.push('simulation-time');
+      if (!config?.timezone) missing.push('timezone');
 
       if (missing.length > 0) {
         return modelNotReady(modelId, missing);
@@ -93,10 +94,12 @@ export function registerExecutionTools(server: McpServer): void {
       }
 
       const weatherConfig = config!.weather as WeatherConfig;
+      const timezone = config!.timezone as string;
 
       const executionOptions = {
         ignitionGeometry,
         timeRange,
+        timezone,
         weatherConfig,
       };
 

--- a/backend/src/mcp/tools/models.ts
+++ b/backend/src/mcp/tools/models.ts
@@ -255,9 +255,11 @@ export function registerModelTools(server: McpServer): void {
           .describe('Simulation start time (ISO 8601, e.g., "2026-06-15T14:00:00Z")'),
         endTime: z.string()
           .describe('Simulation end time (ISO 8601, e.g., "2026-06-15T20:00:00Z")'),
+        timezone: z.string().min(1)
+          .describe('IANA timezone identifier for the ignition location (e.g. "America/Edmonton"). Required — no fallback.'),
       },
     },
-    async ({ modelId, startTime, endTime }): Promise<CallToolResult> => {
+    async ({ modelId, startTime, endTime, timezone }): Promise<CallToolResult> => {
       const repo = getModelRepository();
       const model = await repo.findById(createFireModelId(modelId));
       if (!model) return modelNotFound(modelId);
@@ -284,6 +286,7 @@ export function registerModelTools(server: McpServer): void {
       await repo.saveConfigJson(createFireModelId(modelId), {
         ...existingConfig,
         timeRange,
+        timezone,
       });
 
       return {
@@ -292,7 +295,8 @@ export function registerModelTools(server: McpServer): void {
           text: JSON.stringify({
             modelId,
             timeRange,
-            message: `Simulation time set for model '${model.name}': ${startTime} to ${endTime}.`,
+            timezone,
+            message: `Simulation time set for model '${model.name}': ${startTime} to ${endTime} (${timezone}).`,
           }, null, 2),
         }],
       };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -276,6 +276,7 @@ function AppContent() {
           start: startDateTime.toISOString(),
           end: endDateTime.toISOString(),
         },
+        timezone: data.temporal.timezone,
         weather: weatherConfig,
         scenarios: data.model.runType === 'probabilistic' ? 100 : 1,
         outputMode: data.model.outputMode,

--- a/frontend/src/features/Dashboard/components/ModelList.tsx
+++ b/frontend/src/features/Dashboard/components/ModelList.tsx
@@ -11,6 +11,7 @@ import { useModels } from '../hooks/useModels.js';
 import { useModelSelection } from '../context/DashboardContext.js';
 import { ModelCard } from './ModelCard.js';
 import { isProgressStatus } from './importStatus.js';
+import { buildRerunRequest } from './rerunRequest.js';
 import { useOpenNomad } from '../../../openNomad/index.js';
 import type { Model, ModelStatus, EngineType } from '../../../openNomad/api.js';
 import type { ModelSortOption } from '../context/DashboardContext.js';
@@ -171,22 +172,16 @@ export function ModelList({
         return;
       }
 
-      // Build the /models/run request from stored config
-      const runBody = {
-        name: `${model.name.replace(/ \(imported\)$/, '')} (re-run)`,
-        engineType: config.engineType || model.engine || 'firestarr',
-        ignition: config.ignition,
-        timeRange: config.timeRange,
-        weather: config.weather,
-        scenarios: config.scenarios,
-        modelMode: config.modelMode || model.outputMode || 'probabilistic',
-      };
-
-      if (!runBody.ignition || !runBody.timeRange || !runBody.weather) {
-        setImportStatus('Incomplete config — missing ignition, time range, or weather data');
-        setTimeout(() => setImportStatus(null), 5000);
+      const built = buildRerunRequest(model, config);
+      if (!built.ok) {
+        const message = built.reason === 'missing-timezone'
+          ? 'Incomplete config — missing timezone (was the model exported before timezone support?)'
+          : 'Incomplete config — missing ignition, time range, or weather data';
+        setImportStatus(message);
+        setTimeout(() => setImportStatus(null), 6000);
         return;
       }
+      const runBody = built.body;
 
       setImportStatus('Starting model run...');
       const username = localStorage.getItem('nomad_username') || '';

--- a/frontend/src/features/Dashboard/components/__tests__/buildRerunRequest.test.ts
+++ b/frontend/src/features/Dashboard/components/__tests__/buildRerunRequest.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Re-run request builder — pure logic
+ *
+ * The Dashboard re-run handler builds a /models/run body from the stored
+ * config. This unit covers the exact shape, including timezone forwarding
+ * (regression: re-run was 400'ing on the new fail-fast `Timezone required`
+ * validation because the handler dropped the field).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildRerunRequest } from '../rerunRequest.js';
+
+const fullConfig = {
+  ignition: { type: 'point', coordinates: [-115.7, 60.82] },
+  timeRange: { start: '2023-06-19T19:00:00Z', end: '2023-06-22T19:00:00Z' },
+  weather: { source: 'firestarr_csv' },
+  timezone: 'America/Edmonton',
+  scenarios: 1,
+  modelMode: 'deterministic' as const,
+  engineType: 'firestarr' as const,
+};
+
+const model = { id: 'm1', name: 'Hay River', engine: 'firestarr', outputMode: 'deterministic' as const };
+
+describe('buildRerunRequest', () => {
+  it('forwards timezone from config into runBody', () => {
+    const result = buildRerunRequest(model, fullConfig);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.body.timezone).toBe('America/Edmonton');
+  });
+
+  it('strips trailing " (imported)" suffix and adds " (re-run)" to the name', () => {
+    const result = buildRerunRequest({ ...model, name: 'Hay River (imported)' }, fullConfig);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.body.name).toBe('Hay River (re-run)');
+  });
+
+  it('returns reason="incomplete" when ignition is missing', () => {
+    const result = buildRerunRequest(model, { ...fullConfig, ignition: undefined });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('incomplete');
+  });
+
+  it('returns reason="missing-timezone" when timezone is absent (older export)', () => {
+    const result = buildRerunRequest(model, { ...fullConfig, timezone: undefined });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('missing-timezone');
+  });
+
+  it('returns reason="missing-timezone" when timezone is empty string', () => {
+    const result = buildRerunRequest(model, { ...fullConfig, timezone: '' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('missing-timezone');
+  });
+
+  it('falls back to model.engine when config.engineType is absent', () => {
+    const result = buildRerunRequest(model, { ...fullConfig, engineType: undefined });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.body.engineType).toBe('firestarr');
+  });
+});

--- a/frontend/src/features/Dashboard/components/rerunRequest.ts
+++ b/frontend/src/features/Dashboard/components/rerunRequest.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure builder for the /models/run request body used by the Dashboard re-run
+ * action. Extracted from ModelList.handleRerun so the wiring (and the timezone
+ * fail-fast) is testable in isolation.
+ */
+
+export interface RerunModel {
+  id: string;
+  name: string;
+  engine?: string;
+  outputMode?: 'probabilistic' | 'deterministic' | string | null;
+}
+
+export interface RerunConfig {
+  engineType?: string;
+  ignition?: unknown;
+  timeRange?: unknown;
+  weather?: unknown;
+  scenarios?: number;
+  modelMode?: 'probabilistic' | 'deterministic';
+  timezone?: string;
+}
+
+export type RerunResult =
+  | { ok: true; body: RerunRequestBody }
+  | { ok: false; reason: 'incomplete' | 'missing-timezone' };
+
+export interface RerunRequestBody {
+  name: string;
+  engineType: string;
+  ignition: unknown;
+  timeRange: unknown;
+  weather: unknown;
+  scenarios?: number;
+  modelMode: 'probabilistic' | 'deterministic';
+  timezone: string;
+}
+
+export function buildRerunRequest(model: RerunModel, config: RerunConfig): RerunResult {
+  if (!config.ignition || !config.timeRange || !config.weather) {
+    return { ok: false, reason: 'incomplete' };
+  }
+  if (typeof config.timezone !== 'string' || config.timezone.length === 0) {
+    return { ok: false, reason: 'missing-timezone' };
+  }
+
+  return {
+    ok: true,
+    body: {
+      name: `${model.name.replace(/ \(imported\)$/, '')} (re-run)`,
+      engineType: config.engineType || model.engine || 'firestarr',
+      ignition: config.ignition,
+      timeRange: config.timeRange,
+      weather: config.weather,
+      scenarios: config.scenarios,
+      modelMode: config.modelMode
+        || (model.outputMode === 'deterministic' ? 'deterministic' : 'probabilistic'),
+      timezone: config.timezone,
+    },
+  };
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -211,6 +211,8 @@ export interface RunModelRequest {
     start: string;
     end: string;
   };
+  /** IANA timezone identifier (e.g. "America/Edmonton"). Required by backend. */
+  timezone: string;
   weather: {
     source: 'firestarr_csv' | 'raw_weather' | 'spotwx';
     firestarrCsvContent?: string;


### PR DESCRIPTION
## Summary

Completes the IANA timezone work (#236 follow-up) and fixes three downstream bugs surfaced while verifying it. Four commits, all green:

1. **`884f00d`** — IANA timezone helpers (`computeUtcOffsetHours`, `formatLocalDate/Time/DateTime`) with 9 unit tests. Pure helpers, no wiring.
2. **`e1e5a35`** — End-to-end wiring: `timezone` threaded through `ExecutionOptions` → `FireSTARRParams` → `buildCommand` → `WeatherCSVWriter` → `/models/run` → frontend payload → persisted `output-config.json` → MCP `set-simulation-time` tool. CLI now emits DST-aware `--tz` (Hay River summer = `-6`, winter = `-7`; previously solar approximation gave `-8`). Fail-fast at every boundary; no silent runtime-zone fallback. Also fixes a re-run regression: `ModelList.handleRerun` now forwards `config.timezone` (extracted to a tested pure helper).
3. **`3700818`** — Fixes two off-by-day bugs: animation pipeline was comparing our 1-indexed `julianDayFromDate` against FireSTARR's 0-indexed raster values (first 24h of spread dropped); perimeter labels showed `T+4080h` instead of `T+24h` because they were anchored to year zero, not sim start.
4. **`a749f84`** — Includes FireSTARR pre-warmup cells in animation frame 1 (PR #251 had dropped them; visible as a green halo missing from the slider).

## Test plan

- [x] Backend: 274/274 vitest passing
- [x] Frontend: 273/273 vitest passing
- [x] Backend `tsc` clean, `npm run build` clean
- [x] Frontend `tsc` clean, `npm run build` clean (Vite app + library)
- [x] Local smoke test: Hay River NWT deterministic, ignition 2023-06-19 13:00 MDT
  - FireSTARR command emits `--tz -6` ✓
  - Perimeter labels read `T+0h / T+24h / T+48h` ✓
  - Animation slider Hour 51/51 = `Jun 21 16:00 MDT` (matches simStart + 51h) ✓
  - Frame 1 includes pre-warmup growth halo ✓
- [x] Re-run from Dashboard works for new models (with `config.timezone`); legacy models without timezone show clean "missing timezone" status instead of generic 400

## Notes for review

- `ModelResultsService` line ~290 (`.map` over stored DB results) keeps `timeOffsetHours = null` with a `TODO(#236-followup)` — that path runs for probabilistic-mode results where `startJulian` isn't yet in scope. Future cleanup, not urgent (deterministic perimeters at line ~480 are correct).
- `package-lock.json` was dirty before this branch was cut and was left untouched.
- `frontend/dist/` and `frontend/nomad-frontend-0.7.0.tgz` are local build artifacts (gitignored) and not in the PR.
