### PR TITLE
fix(rnd): topGutter prop + viewport-aware bounds for floating panels

### DIFF
--- a/frontend/src/features/Dashboard/components/DashboardContainer.tsx
+++ b/frontend/src/features/Dashboard/components/DashboardContainer.tsx
@@ -114,6 +114,13 @@ export interface DashboardContainerProps {
    * @example { export: true, compare: false, drafts: true }
    */
   features?: NomadFeaturesType;
+
+  /**
+   * Reserved space at the top of the viewport (e.g. an embedding host's
+   * header). The dashboard will not initialize, drag, or resize above this y
+   * in floating mode. Defaults to 0 for standalone Nomad.
+   */
+  topGutter?: number;
 }
 
 // =============================================================================
@@ -301,6 +308,7 @@ interface FloatingDashboardProps extends DashboardContentProps {
   onAddGeoJsonToMap?: (output: OutputItem, geoJson: GeoJSON.GeoJSON, modelInfo?: { modelId: string; modelName: string; engineType: string }) => void;
   onAddRasterToMap?: (output: OutputItem, bounds: [number, number, number, number], tileUrl: string, modelInfo?: { modelId: string; modelName: string; engineType: string }) => void;
   className?: string;
+  topGutter?: number;
 }
 
 function FloatingDashboard({
@@ -312,8 +320,8 @@ function FloatingDashboard({
   onAddGeoJsonToMap,
   onAddRasterToMap,
   className = '',
+  topGutter = 0,
 }: FloatingDashboardProps) {
-  const [size, setSize] = useState({ width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT });
   const { activeView, wizardDraftId, resultsModelId, showDashboard } = useDashboardView();
   const labels = useNomadLabels();
   const { theme } = useNomadCustomizationOptional();
@@ -332,6 +340,16 @@ function FloatingDashboard({
   // Calculate initial position (right side of screen)
   const [initialX] = useState(() => Math.max(20, window.innerWidth - DEFAULT_WIDTH - 40));
   const [initialY] = useState(() => 70);
+
+  // Effective bounds account for an optional top gutter (e.g. an embedding
+  // host's header). Mirrors the contract in ModelReviewPanel and
+  // ModelSetupWizard so a single topGutter prop handles all floating panels.
+  const effectiveMaxHeight = Math.max(MIN_HEIGHT, windowHeight - topGutter - 32);
+  const clampedInitialY = Math.max(initialY, topGutter);
+  const clampedDefaultHeight = Math.min(DEFAULT_HEIGHT, effectiveMaxHeight);
+
+  // Controlled position so onDragStop can re-clamp y above the gutter.
+  const [position, setPosition] = useState({ x: initialX, y: clampedInitialY });
 
   // Handle wizard completion
   const handleWizardComplete = useCallback(async (data: ModelSetupData) => {
@@ -354,6 +372,7 @@ function FloatingDashboard({
         onComplete={handleWizardComplete}
         onCancel={handleWizardCancel}
         draftId={wizardDraftId ?? undefined}
+        topGutter={topGutter}
       />
     );
   }
@@ -367,15 +386,18 @@ function FloatingDashboard({
         mode="floating"
         onAddToMap={onAddGeoJsonToMap}
         onAddRasterToMap={onAddRasterToMap}
+        topGutter={topGutter}
       />
     );
   }
 
-  // Dynamic panel styles using theme
+  // Dynamic panel styles using theme. The inner div fills the Rnd wrapper so
+  // resize/drag changes flow purely through react-rnd; no inline width/height
+  // here keeps the panel from drifting out of sync after a window resize.
   const panelDynamic: CSSProperties = {
     ...panelStyle,
-    width: size.width,
-    height: size.height,
+    width: '100%',
+    height: '100%',
     backgroundColor: theme['--nomad-surface'],
     borderRadius: theme['--nomad-border-radius'],
     boxShadow: theme['--nomad-shadow'],
@@ -449,21 +471,22 @@ function FloatingDashboard({
     <Rnd
       default={{
         x: initialX,
-        y: initialY,
+        y: clampedInitialY,
         width: DEFAULT_WIDTH,
-        height: DEFAULT_HEIGHT,
+        height: clampedDefaultHeight,
       }}
+      position={position}
       minWidth={MIN_WIDTH}
       minHeight={MIN_HEIGHT}
-      maxHeight={windowHeight - 32}
+      maxHeight={effectiveMaxHeight}
       bounds="parent"
       dragHandleClassName="dashboard-drag-handle"
       style={{ zIndex: 900 }}
-      onResize={(_e, _dir, ref) => {
-        setSize({
-          width: ref.offsetWidth,
-          height: ref.offsetHeight,
-        });
+      onDragStop={(_e, data) => {
+        setPosition({ x: data.x, y: Math.max(data.y, topGutter) });
+      }}
+      onResizeStop={(_e, _dir, _ref, _delta, pos) => {
+        setPosition({ x: pos.x, y: Math.max(pos.y, topGutter) });
       }}
       enableResizing={{
         top: false,
@@ -623,6 +646,7 @@ function InnerDashboard({
   onAddRasterToMap,
   initialTab = 'models',
   className,
+  topGutter,
 }: InnerDashboardProps) {
   // Initial state for context
   const initialState = useMemo(() => ({ activeTab: initialTab }), [initialTab]);
@@ -639,6 +663,7 @@ function InnerDashboard({
           onAddGeoJsonToMap={onAddGeoJsonToMap}
           onAddRasterToMap={onAddRasterToMap}
           className={className}
+          topGutter={topGutter}
         />
       ) : (
         <EmbeddedDashboard

--- a/frontend/src/features/ModelReview/components/ModelReviewPanel.tsx
+++ b/frontend/src/features/ModelReview/components/ModelReviewPanel.tsx
@@ -29,6 +29,12 @@ interface ModelReviewPanelProps {
   onAddToMap?: (output: OutputItem, geoJson: GeoJSON.GeoJSON, modelInfo?: { modelId: string; modelName: string; engineType: string }) => void;
   /** Called when raster output is added to main map */
   onAddRasterToMap?: (output: OutputItem, bounds: [number, number, number, number], tileUrl: string, modelInfo?: { modelId: string; modelName: string; engineType: string }) => void;
+  /**
+   * Reserved space at the top of the viewport (e.g. an embedding host's
+   * header). The panel will not initialize, drag, or resize above this y.
+   * Defaults to 0 for standalone Nomad.
+   */
+  topGutter?: number;
 }
 
 /**
@@ -47,11 +53,11 @@ export function ModelReviewPanel({
   mode = 'floating',
   onAddToMap,
   onAddRasterToMap,
+  topGutter = 0,
 }: ModelReviewPanelProps) {
   const api = useOpenNomad();
   const { results, isLoading, error, refetch } = useModelResults(modelId);
   const [showExportPanel, setShowExportPanel] = useState(false);
-  const [size, setSize] = useState({ width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT });
 
   // Responsive
   const [windowWidth, setWindowWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1024);
@@ -82,6 +88,16 @@ export function ModelReviewPanel({
   // Calculate initial position — viewport-aware
   const [initialX] = useState(() => Math.min(180, Math.max(10, windowWidth - DEFAULT_WIDTH - 20)));
   const [initialY] = useState(() => Math.min(70, Math.max(10, windowHeight - DEFAULT_HEIGHT - 20)));
+
+  // Effective bounds account for an optional top gutter (e.g. an embedding
+  // host's header). The panel can never initialize, drag, or resize above this
+  // y; the bottom margin (32px) keeps the resize handle off-screen.
+  const effectiveMaxHeight = Math.max(MIN_HEIGHT, windowHeight - topGutter - 32);
+  const clampedInitialY = Math.max(initialY, topGutter);
+  const clampedDefaultHeight = Math.min(DEFAULT_HEIGHT, effectiveMaxHeight);
+
+  // Controlled position so onDragStop can re-clamp y above the gutter.
+  const [position, setPosition] = useState({ x: initialX, y: clampedInitialY });
 
   /**
    * Handle download request
@@ -405,21 +421,22 @@ export function ModelReviewPanel({
       <Rnd
         default={{
           x: initialX,
-          y: initialY,
+          y: clampedInitialY,
           width: DEFAULT_WIDTH,
-          height: DEFAULT_HEIGHT,
+          height: clampedDefaultHeight,
         }}
+        position={position}
         minWidth={MIN_WIDTH}
         minHeight={MIN_HEIGHT}
-        maxHeight={windowHeight - 32}
+        maxHeight={effectiveMaxHeight}
         bounds="parent"
         dragHandleClassName="model-results-drag-handle"
         style={{ zIndex: 1000 }}
-        onResize={(_e, _dir, ref) => {
-          setSize({
-            width: ref.offsetWidth,
-            height: ref.offsetHeight,
-          });
+        onDragStop={(_e, data) => {
+          setPosition({ x: data.x, y: Math.max(data.y, topGutter) });
+        }}
+        onResizeStop={(_e, _dir, _ref, _delta, pos) => {
+          setPosition({ x: pos.x, y: Math.max(pos.y, topGutter) });
         }}
         enableResizing={{
           top: false,
@@ -432,7 +449,7 @@ export function ModelReviewPanel({
           topLeft: false,
         }}
       >
-        <div style={{ ...panelStyle, width: size.width, height: size.height }}>
+        <div style={{ ...panelStyle, width: '100%', height: '100%' }}>
           {renderHeader()}
           {renderContent()}
         </div>

--- a/frontend/src/features/ModelReview/components/__tests__/ModelReviewPanel.test.tsx
+++ b/frontend/src/features/ModelReview/components/__tests__/ModelReviewPanel.test.tsx
@@ -21,10 +21,15 @@ import type { ModelResultsResponse } from '../../types';
 // Mocks
 // =============================================================================
 
-// Mock react-rnd to detect when Rnd is rendered
+// Mock react-rnd: capture props for inspection while still rendering children.
+// HTML attributes can't carry object props faithfully, so we keep them in a
+// module-level slot that tests read directly.
+let lastRndProps: Record<string, unknown> = {};
 vi.mock('react-rnd', () => ({
-  Rnd: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
-    React.createElement('div', { 'data-testid': 'rnd-wrapper', ...props }, children),
+  Rnd: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) => {
+    lastRndProps = props;
+    return React.createElement('div', { 'data-testid': 'rnd-wrapper' }, children);
+  },
 }));
 
 const mockResultsResponse: ModelResultsResponse = {
@@ -157,5 +162,55 @@ describe('ModelReviewPanel - mode awareness', () => {
 
     renderPanel({ mode: 'embedded' });
     expect(screen.getByText('Model Results')).toBeTruthy();
+  });
+});
+
+// =============================================================================
+// EM3 #468 — topGutter / viewport-aware bounds
+// =============================================================================
+
+describe('ModelReviewPanel - topGutter / Rnd bounds', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubGlobal('innerWidth', 1440);
+    vi.stubGlobal('innerHeight', 900);
+    lastRndProps = {};
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('without topGutter, default.y stays at the panel-derived initial y', () => {
+    renderPanel({ mode: 'floating' });
+    const def = lastRndProps.default as { x: number; y: number; width: number; height: number };
+    expect(def.y).toBeGreaterThanOrEqual(0);
+  });
+
+  it('with topGutter=60, default.y is clamped to be at least 60', () => {
+    renderPanel({ mode: 'floating', topGutter: 60 });
+    const def = lastRndProps.default as { x: number; y: number; width: number; height: number };
+    expect(def.y).toBeGreaterThanOrEqual(60);
+  });
+
+  it('with topGutter=60, maxHeight reserves space for the gutter and bottom margin', () => {
+    renderPanel({ mode: 'floating', topGutter: 60 });
+    expect(lastRndProps.maxHeight).toBe(900 - 60 - 32);
+  });
+
+  it('default.height never exceeds the effective maxHeight', () => {
+    renderPanel({ mode: 'floating', topGutter: 60 });
+    const def = lastRndProps.default as { x: number; y: number; width: number; height: number };
+    const max = lastRndProps.maxHeight as number;
+    expect(def.height).toBeLessThanOrEqual(max);
+  });
+
+  it('exposes a controlled position so onDragStop can clamp y', () => {
+    renderPanel({ mode: 'floating', topGutter: 60 });
+    expect(lastRndProps.position).toBeDefined();
+    const pos = lastRndProps.position as { x: number; y: number };
+    expect(pos.y).toBeGreaterThanOrEqual(60);
+    expect(typeof lastRndProps.onDragStop).toBe('function');
   });
 });

--- a/frontend/src/features/ModelSetup/components/ModelSetupWizard.tsx
+++ b/frontend/src/features/ModelSetup/components/ModelSetupWizard.tsx
@@ -53,6 +53,12 @@ export interface ModelSetupWizardProps {
   onCancel?: () => void;
   /** Optional draft ID to resume */
   draftId?: string;
+  /**
+   * Reserved space at the top of the viewport (e.g. an embedding host's
+   * header). The wizard will not initialize, drag, or resize above this y.
+   * Defaults to 0 for standalone Nomad.
+   */
+  topGutter?: number;
 }
 
 // Breakpoints
@@ -208,23 +214,30 @@ function StepRouter() {
 /**
  * Model Setup Wizard component
  */
-export function ModelSetupWizard({ onComplete, onCancel, draftId }: ModelSetupWizardProps) {
+export function ModelSetupWizard({ onComplete, onCancel, draftId, topGutter = 0 }: ModelSetupWizardProps) {
   const { windowSize, isMobile, isTablet } = useResponsive();
   const styles = getStyles(isMobile, isTablet);
 
-  // Calculate initial dimensions - respect viewport size
+  // Calculate initial dimensions - respect viewport size and top gutter
   const [initialDimensions] = useState(() => {
-    const maxHeight = window.innerHeight - VIEWPORT_MARGIN;
+    const maxHeight = window.innerHeight - VIEWPORT_MARGIN - topGutter;
     const height = Math.min(DEFAULT_HEIGHT, maxHeight);
     const width = Math.min(DEFAULT_WIDTH, window.innerWidth - VIEWPORT_MARGIN);
     const x = Math.max(VIEWPORT_MARGIN / 2, (window.innerWidth - width) / 2);
-    const y = Math.max(VIEWPORT_MARGIN / 2, (window.innerHeight - height) / 2);
+    const yCentered = Math.max(VIEWPORT_MARGIN / 2, (window.innerHeight - height) / 2);
+    const y = Math.max(yCentered, topGutter);
     return { x, y, width, height };
   });
 
-  const [size, setSize] = useState({
-    width: initialDimensions.width,
-    height: initialDimensions.height
+  // Effective bounds for the floating Rnd. Mirrors the topGutter contract used
+  // by ModelReviewPanel and DashboardContainer so an embedding host (e.g. EM3)
+  // can pass a single prop and have all panels respect its header.
+  const effectiveMaxHeight = Math.max(MIN_HEIGHT, windowSize.height - VIEWPORT_MARGIN - topGutter);
+
+  // Controlled position so onDragStop can re-clamp y above the gutter.
+  const [position, setPosition] = useState({
+    x: initialDimensions.x,
+    y: initialDimensions.y,
   });
 
   const handleComplete = useCallback(
@@ -378,18 +391,19 @@ export function ModelSetupWizard({ onComplete, onCancel, draftId }: ModelSetupWi
         width: initialDimensions.width,
         height: initialDimensions.height,
       }}
+      position={position}
       minWidth={MIN_WIDTH}
       minHeight={MIN_HEIGHT}
       maxWidth={800}
-      maxHeight={windowSize.height - VIEWPORT_MARGIN}
+      maxHeight={effectiveMaxHeight}
       bounds="parent"
       dragHandleClassName="wizard-drag-handle"
       style={{ zIndex: 1000 }}
-      onResize={(_e, _direction, ref) => {
-        setSize({
-          width: ref.offsetWidth,
-          height: ref.offsetHeight,
-        });
+      onDragStop={(_e, data) => {
+        setPosition({ x: data.x, y: Math.max(data.y, topGutter) });
+      }}
+      onResizeStop={(_e, _dir, _ref, _delta, pos) => {
+        setPosition({ x: pos.x, y: Math.max(pos.y, topGutter) });
       }}
       enableResizing={{
         top: false,
@@ -402,7 +416,7 @@ export function ModelSetupWizard({ onComplete, onCancel, draftId }: ModelSetupWi
         topLeft: false,
       }}
     >
-      <div style={{ ...styles.wizardInnerStyle, width: size.width, height: size.height }}>
+      <div style={{ ...styles.wizardInnerStyle, width: '100%', height: '100%' }}>
         <WizardContainer config={config}>
           <div style={styles.headerStyle} className="wizard-drag-handle">
             <h2 style={styles.titleStyle}>


### PR DESCRIPTION
## Summary

Closes [intellifire/intellifire_easymap3#468](https://github.com/intellifire/intellifire_easymap3/issues/468) by moving the fix into `@nomad/frontend` so EM3 can drop its SCSS + MutationObserver hack from `FireModelingDashboard`.

Adds a `topGutter` prop (default `0`) to `ModelReviewPanel`, `ModelSetupWizard`, and `DashboardContainer`. EM3 will pass `topGutter={60}` to compensate for its top bar; standalone Nomad keeps current behavior.

The prop:
- clamps `default.y` and `default.height` into the available space
- reduces `effectiveMaxHeight` so panels can't resize past the viewport
- controls `position` so `onDragStop` / `onResizeStop` re-clamp y above the gutter
- flows from `DashboardContainer` through to its rendered Wizard / Review children so one prop covers all floating panels

Inner divs now fill the Rnd wrapper (`height/width: 100%`) instead of mirroring a separate `size` state. That removes the stale-inline-height drift symptom EM3 hacked around with `.react-draggable-dragged > div { height: 100% !important }`, and lets us drop the now-dead `size` state + `onResize` handlers.

## Test plan

- [x] `npx vitest run` — 278/278 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean prod build
- [x] New specs in `ModelReviewPanel.test.tsx` cover the `topGutter` contract (default y clamp, maxHeight reservation, default.height ≤ maxHeight, controlled position)
- [ ] EM3 (Meridian) confirms the SCSS + MutationObserver hack can be removed after this lands
