### PR TITLE
Sprint 17: weather validation, timezone correctness, and failures that say what is wrong

### DIFF
--- a/backend/src/api/__tests__/modelsPreflight.test.ts
+++ b/backend/src/api/__tests__/modelsPreflight.test.ts
@@ -205,6 +205,15 @@ describe('POST /models/preflight', () => {
       expect(JSON.stringify(res.body)).toMatch(/start|ignition/i);
     });
 
+    it('rejects an unknown timezone as a client error, not a 500 (#353)', async () => {
+      const res = await request(app)
+        .post('/api/v1/models/preflight')
+        .send(validBody({ timezone: 'Mars/Olympus_Mons' }));
+
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toMatch(/timezone/i);
+    });
+
     it('rejects a missing weather config', async () => {
       const body = validBody();
       delete (body as Record<string, unknown>).weather;

--- a/backend/src/api/__tests__/modelsPreflight.test.ts
+++ b/backend/src/api/__tests__/modelsPreflight.test.ts
@@ -148,6 +148,44 @@ describe('POST /models/preflight', () => {
     expect(res.body.jobId).toBeUndefined();
   });
 
+  describe('timezone contract (#354)', () => {
+    it("tells the user how far their file sits from the contract", async () => {
+      // The Date column is local time in the model's timezone, and daily codes
+      // are recorded at noon. Her rows read 19:06 with Edmonton declared —
+      // six hours ahead, which is exactly UTC.
+      const res = await request(app).post('/api/v1/models/preflight').send(validBody());
+
+      expect(res.body.rhythm.dailyHour).toBe(19);
+      expect(res.body.rhythm.hoursFromNoon).toBe(6);
+      expect(res.body.rhythm.likelyZoneMismatch).toBe(true);
+    });
+
+    it('reports no mismatch for a file that does record at local noon', async () => {
+      const onContract = [
+        HEADER,
+        blankRow('2026-08-01 00:06:00'),
+        dailyRow('2026-08-01 13:00:00', 81.66, 19.22, 412.67),
+        blankRow('2026-08-02 00:06:00'),
+        dailyRow('2026-08-02 13:00:00', 84.65, 20.72, 424.9),
+      ].join('\n');
+
+      const res = await request(app)
+        .post('/api/v1/models/preflight')
+        .send(validBody({ weather: { source: 'firestarr_csv', firestarrCsvContent: onContract } }));
+
+      expect(res.body.rhythm.likelyZoneMismatch).toBe(false);
+      expect(res.body.rhythm.hoursFromNoon).toBe(0);
+    });
+
+    it('reports no rhythm for a conforming file — every hour has codes, so there is none', async () => {
+      const res = await request(app)
+        .post('/api/v1/models/preflight')
+        .send(validBody({ weather: { source: 'firestarr_csv', firestarrCsvContent: FULLY_POPULATED_CSV } }));
+
+      expect(res.body.rhythm).toBeNull();
+    });
+  });
+
   describe('fail-fast validation', () => {
     it('rejects a missing timezone', async () => {
       const body = validBody();

--- a/backend/src/api/__tests__/modelsPreflight.test.ts
+++ b/backend/src/api/__tests__/modelsPreflight.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Pre-flight weather check — issue #351.
+ *
+ * A FireSTARR-format CSV that carries CFFDRS values on daily rows only satisfies
+ * neither supported contract. Uploaded as firestarr_csv it parses to NaN on every
+ * other row, and those NaNs reach the FireSTARR command line and segfault it.
+ *
+ * This endpoint answers one question before any job exists: does this file have
+ * the daily-only shape, and if so what starting codes does it already contain?
+ * It creates nothing — no model, no job, no sim directory.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import preflightRouter from '../routes/v1/preflight.js';
+
+const ZONE = 'America/Edmonton';
+
+const HEADER = 'Scenario,Date,PREC,TEMP,RH,WS,WD,FFMC,DMC,DC,ISI,BUI,FWI';
+
+/** An hourly observation with no CFFDRS values — empty columns, as her file has. */
+function blankRow(timestamp: string): string {
+  return `0,${timestamp},0,24.4,46,10.2,222,,,,,,`;
+}
+
+/** The daily reading — the one row per day that carries the indices. */
+function dailyRow(timestamp: string, ffmc: number, dmc: number, dc: number): string {
+  return `0,${timestamp},0,23.8,61,7.5,217,${ffmc},${dmc},${dc},2,34.44,4.64`;
+}
+
+/** Vita's file: hourly observations, indices once a day at 19:06. */
+const DAILY_ONLY_CSV = [
+  HEADER,
+  blankRow('2026-08-01 00:06:00'),
+  dailyRow('2026-08-01 19:06:00', 81.66, 19.22, 412.67),
+  blankRow('2026-08-02 00:06:00'),
+  dailyRow('2026-08-02 19:06:00', 76.3, 18.52, 418.6),
+  blankRow('2026-08-03 00:06:00'),
+  dailyRow('2026-08-03 19:06:00', 84.65, 20.72, 424.9),
+  blankRow('2026-08-04 00:06:00'),
+  dailyRow('2026-08-04 19:06:00', 88.44, 23.66, 432.05),
+].join('\n');
+
+/** A conforming file — indices on every row. */
+const FULLY_POPULATED_CSV = [
+  HEADER,
+  dailyRow('2026-08-01 00:06:00', 81.66, 19.22, 412.67),
+  dailyRow('2026-08-01 01:06:00', 81.7, 19.3, 412.8),
+].join('\n');
+
+/** 2026-08-04 12:00 local MDT — her ignition. */
+const IGNITION = '2026-08-04T18:00:00Z';
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    timezone: ZONE,
+    timeRange: { start: IGNITION, end: '2026-08-07T18:00:00Z' },
+    weather: { source: 'firestarr_csv', firestarrCsvContent: DAILY_ONLY_CSV },
+    ...overrides,
+  };
+}
+
+describe('POST /models/preflight', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json({ limit: '50mb' }));
+    app.use('/api/v1', preflightRouter);
+    app.use(
+      (
+        err: { httpStatus?: number; statusCode?: number; message: string },
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+      ) => {
+        res.status(err.httpStatus ?? err.statusCode ?? 500).json({ error: err.message });
+      },
+    );
+  });
+
+  it("finds the codes already in vita's file and reports the daily-only shape", async () => {
+    const res = await request(app).post('/api/v1/models/preflight').send(validBody());
+
+    expect(res.status).toBe(200);
+    expect(res.body.dailyOnlyCffdrs).toBe(true);
+    expect(res.body.candidate).not.toBeNull();
+    expect(res.body.candidate.ffmc).toBe(84.65);
+    expect(res.body.candidate.dmc).toBe(20.72);
+    expect(res.body.candidate.dc).toBe(424.9);
+  });
+
+  it('labels the reading so a human can recognise it in their own file', async () => {
+    const res = await request(app).post('/api/v1/models/preflight').send(validBody());
+    expect(res.body.candidate.localLabel).toBe('2026-08-03, 1900');
+  });
+
+  it('offers the reading before ignition, not the one after it', async () => {
+    // Aug 4's 19:06 reading is later than her noon ignition. Using it would be
+    // wrong for every morning fire.
+    const res = await request(app).post('/api/v1/models/preflight').send(validBody());
+    expect(res.body.candidate.ffmc).not.toBe(88.44);
+  });
+
+  it('reports nothing to fix for a conforming file', async () => {
+    const res = await request(app)
+      .post('/api/v1/models/preflight')
+      .send(validBody({ weather: { source: 'firestarr_csv', firestarrCsvContent: FULLY_POPULATED_CSV } }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.dailyOnlyCffdrs).toBe(false);
+    expect(res.body.candidate).toBeNull();
+  });
+
+  it('reports nothing to fix when the source is not a FireSTARR CSV', async () => {
+    // raw_weather already carries explicit starting codes. Nothing to detect.
+    const res = await request(app)
+      .post('/api/v1/models/preflight')
+      .send(validBody({ weather: { source: 'raw_weather', rawWeatherContent: 'irrelevant' } }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.dailyOnlyCffdrs).toBe(false);
+    expect(res.body.candidate).toBeNull();
+  });
+
+  it('reports the shape but offers nothing when no reading precedes ignition', async () => {
+    // The caller must not invent codes. It has to refuse.
+    const res = await request(app)
+      .post('/api/v1/models/preflight')
+      .send(validBody({ timeRange: { start: '2026-08-01T12:00:00Z', end: '2026-08-04T12:00:00Z' } }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.dailyOnlyCffdrs).toBe(true);
+    expect(res.body.candidate).toBeNull();
+  });
+
+  it('survives a file full of NaN rather than failing on it', async () => {
+    // The whole point. This endpoint exists to diagnose exactly the file that
+    // breaks everything downstream, so it must not break on it itself.
+    const res = await request(app).post('/api/v1/models/preflight').send(validBody());
+    expect(res.status).toBe(200);
+  });
+
+  it('creates no model and no job — it only reads', async () => {
+    const res = await request(app).post('/api/v1/models/preflight').send(validBody());
+    expect(res.body.modelId).toBeUndefined();
+    expect(res.body.jobId).toBeUndefined();
+  });
+
+  describe('fail-fast validation', () => {
+    it('rejects a missing timezone', async () => {
+      const body = validBody();
+      delete (body as Record<string, unknown>).timezone;
+
+      const res = await request(app).post('/api/v1/models/preflight').send(body);
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toMatch(/timezone/i);
+    });
+
+    it('rejects a missing timeRange.start — there is no ignition without it', async () => {
+      const res = await request(app)
+        .post('/api/v1/models/preflight')
+        .send(validBody({ timeRange: { end: '2026-08-07T18:00:00Z' } }));
+
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toMatch(/start|ignition/i);
+    });
+
+    it('rejects a missing weather config', async () => {
+      const body = validBody();
+      delete (body as Record<string, unknown>).weather;
+
+      const res = await request(app).post('/api/v1/models/preflight').send(body);
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toMatch(/weather/i);
+    });
+
+    it('rejects an unparseable CSV with a message naming the problem', async () => {
+      const res = await request(app)
+        .post('/api/v1/models/preflight')
+        .send(validBody({ weather: { source: 'firestarr_csv', firestarrCsvContent: 'not,a,weather,file\n1,2,3,4' } }));
+
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toMatch(/column|parse|csv/i);
+    });
+  });
+});
+
+describe('route registration', () => {
+  it('is reachable through the real v1 router, not just when mounted directly', async () => {
+    // Guards the gap the suite above cannot see: every test there mounts
+    // preflightRouter by hand, so they would all pass even if the app never
+    // wired it in.
+    const { default: v1Router } = await import('../routes/v1/index.js');
+
+    const realApp = express();
+    realApp.use(express.json({ limit: '50mb' }));
+    realApp.use('/api/v1', v1Router);
+
+    const res = await request(realApp).post('/api/v1/models/preflight').send(validBody());
+
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/backend/src/api/__tests__/modelsRunContract.test.ts
+++ b/backend/src/api/__tests__/modelsRunContract.test.ts
@@ -1,0 +1,139 @@
+/**
+ * POST /models/run rejects weather that FireSTARR cannot use — #339, #340, #341.
+ *
+ * Reproduces the CIFFC demo failures of 2026-08-19: four of six runs died with
+ * FATAL: map::at about ten seconds in, every one with a weather series whose
+ * first day began after noon. The user saw "Process exited with code 1"; the
+ * actual reason was only in the container log.
+ *
+ * These must now come back as a 400 that says what is wrong, before any model,
+ * job or simulation directory exists.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import modelsRouter from '../routes/v1/models.js';
+
+const ZONE = 'America/Edmonton';
+const HEADER = 'Scenario,Date,PREC,TEMP,RH,WS,WD,FFMC,DMC,DC,ISI,BUI,FWI';
+
+/** Hourly rows across the given local hours of a day, all indices populated. */
+function rows(day: string, from: number, to: number): string[] {
+  const out: string[] = [];
+  for (let h = from; h <= to; h++) {
+    out.push(`0,${day} ${String(h).padStart(2, '0')}:00:00,0,20,45,10,180,85,30,200,5,40,10`);
+  }
+  return out;
+}
+
+function csv(...lines: string[][]): string {
+  return [HEADER, ...lines.flat()].join('\n');
+}
+
+function body(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'contract test',
+    engineType: 'firestarr',
+    ignition: { type: 'point', coordinates: [-113.5, 53.5] },
+    timeRange: { start: '2026-08-04T18:00:00.000Z', end: '2026-08-05T18:00:00.000Z' },
+    timezone: ZONE,
+    weather: {
+      source: 'firestarr_csv',
+      firestarrCsvContent: csv(rows('2026-08-04', 0, 23), rows('2026-08-05', 0, 23)),
+    },
+    ...overrides,
+  };
+}
+
+describe('POST /models/run — FireSTARR weather contract', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json({ limit: '50mb' }));
+    app.use('/api/v1', modelsRouter);
+    app.use(
+      (
+        err: { httpStatus?: number; statusCode?: number; message: string },
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+      ) => {
+        res.status(err.httpStatus ?? err.statusCode ?? 500).json({ error: err.message });
+      },
+    );
+  });
+
+  it("rejects Danny's shape — a first day beginning after noon", async () => {
+    const res = await request(app)
+      .post('/api/v1/models/run')
+      .send(
+        body({
+          weather: {
+            source: 'firestarr_csv',
+            firestarrCsvContent: csv(rows('2026-08-04', 17, 23), rows('2026-08-05', 0, 23)),
+          },
+          timeRange: { start: '2026-08-05T18:00:00.000Z', end: '2026-08-05T23:00:00.000Z' },
+        }),
+      );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/noon|12:00/i);
+    expect(res.body.error).toMatch(/2026-08-04/);
+  });
+
+  it('says how to fix it rather than only that it failed', async () => {
+    const res = await request(app)
+      .post('/api/v1/models/run')
+      .send(
+        body({
+          weather: {
+            source: 'firestarr_csv',
+            firestarrCsvContent: csv(rows('2026-08-04', 23, 23), rows('2026-08-05', 0, 23)),
+          },
+          timeRange: { start: '2026-08-05T18:00:00.000Z', end: '2026-08-05T23:00:00.000Z' },
+        }),
+      );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/trim|start the model/i);
+  });
+
+  it('rejects an ignition before the first noon record (#341)', async () => {
+    // 09:00 local, with the first CFFDRS at noon that day.
+    const res = await request(app)
+      .post('/api/v1/models/run')
+      .send(body({ timeRange: { start: '2026-08-04T15:00:00.000Z', end: '2026-08-05T18:00:00.000Z' } }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/ignition/i);
+  });
+
+  it('rejects an ignition after the weather ends', async () => {
+    const res = await request(app)
+      .post('/api/v1/models/run')
+      .send(body({ timeRange: { start: '2026-08-09T18:00:00.000Z', end: '2026-08-10T18:00:00.000Z' } }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/ignition/i);
+  });
+
+  it('lets conforming weather THROUGH — the check must not reject everything', async () => {
+    // Every other test here asserts a rejection, so all of them would still
+    // pass if the check refused every request. This is the one that would not.
+    const res = await request(app).post('/api/v1/models/run').send(body());
+
+    expect(res.status).not.toBe(400);
+    expect(JSON.stringify(res.body)).not.toMatch(/noon|ignition is before/i);
+  });
+
+  it('reports an unreadable CSV as a client error naming the parser reason', async () => {
+    const res = await request(app)
+      .post('/api/v1/models/run')
+      .send(body({ weather: { source: 'firestarr_csv', firestarrCsvContent: 'not,a,weather,file\n1,2,3,4' } }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/could not be read|column/i);
+  });
+});

--- a/backend/src/api/routes/v1/index.ts
+++ b/backend/src/api/routes/v1/index.ts
@@ -3,6 +3,7 @@ import healthRouter from './health.js';
 import configRouter from './config.js';
 import jobsRouter from './jobs.js';
 import modelsRouter from './models.js';
+import preflightRouter from './preflight.js';
 import resultsRouter from './results.js';
 import exportsRouter from './exports.js';
 import settingsRouter from './settings.js';
@@ -27,6 +28,7 @@ router.use(healthRouter);   // /health, /info
 router.use(configRouter);   // /config
 router.use(jobsRouter);     // /jobs/:id
 router.use(modelsRouter);   // /models/:id, /models/:id/execute, /models/:id/results
+router.use(preflightRouter); // /models/preflight
 router.use(resultsRouter);  // /results/:id/preview, /results/:id/download
 router.use(exportsRouter);  // /exports, /exports/:id/download, /exports/:id/share, /share/:token
 router.use(settingsRouter);       // /settings/:key

--- a/backend/src/api/routes/v1/models.ts
+++ b/backend/src/api/routes/v1/models.ts
@@ -28,6 +28,7 @@ import { getModelRepository, getResultRepository } from '../../../infrastructure
 import type { ExecutionOptions, ModelMode } from '../../../application/interfaces/IFireModelingEngine.js';
 import type { WeatherConfig } from '../../../infrastructure/weather/types.js';
 import { parseIsoToDate } from '../../../shared/dateParsing.js';
+import { assertWeatherMeetsEngineContract } from '../../../application/services/WeatherContractCheck.js';
 
 const VALID_MODEL_MODES: ModelMode[] = ['probabilistic', 'deterministic', 'long-term-risk'];
 
@@ -169,6 +170,28 @@ router.post(
     const timeRange = new TimeRange(
       parseIsoToDate(body.timeRange.start, 'POST /models body.timeRange.start'),
       parseIsoToDate(body.timeRange.end, 'POST /models body.timeRange.end'),
+    );
+
+    // Check the weather against FireSTARR's input contract BEFORE anything is
+    // created (#339, #340, #341). FireSTARR builds its daily fire weather from
+    // each day's noon record; a day without one throws FATAL: map::at about ten
+    // seconds in, with the reason only in the container log. Four of six runs
+    // on the CIFFC demo died that way on 2026-08-19. Failing here means a 400
+    // naming the problem while the user can still fix it, and no orphaned model,
+    // job or sim directory to clean up.
+    const ignitionLatitude = Array.isArray(body.ignition.coordinates[0])
+      ? (body.ignition.coordinates as [number, number][])[0][1]
+      : (body.ignition.coordinates as [number, number])[1];
+    const ignitionLongitude = Array.isArray(body.ignition.coordinates[0])
+      ? (body.ignition.coordinates as [number, number][])[0][0]
+      : (body.ignition.coordinates as [number, number])[0];
+
+    await assertWeatherMeetsEngineContract(
+      body.weather,
+      timeRange.start,
+      body.timezone,
+      { latitude: ignitionLatitude, longitude: ignitionLongitude },
+      { start: timeRange.start, end: timeRange.end },
     );
 
     // Create model with queued status (skip draft)

--- a/backend/src/api/routes/v1/preflight.ts
+++ b/backend/src/api/routes/v1/preflight.ts
@@ -9,6 +9,7 @@ import { Router, type Request, type Response, type NextFunction } from 'express'
 import { ValidationError } from '../../../domain/errors/index.js';
 import { preflightWeather } from '../../../application/services/WeatherPreflightService.js';
 import { parseIsoToDate } from '../../../shared/dateParsing.js';
+import { IANAZone } from 'luxon';
 
 const router = Router();
 
@@ -33,6 +34,14 @@ router.post('/models/preflight', async (req: Request, res: Response, next: NextF
     if (typeof timezone !== 'string' || timezone.trim() === '') {
       throw new ValidationError('timezone is required (IANA identifier)', [
         { field: 'timezone', message: 'required' },
+      ]);
+    }
+
+    // Reject an unresolvable zone here so it surfaces as a client error rather
+    // than a 500 from deeper in the stack (#353).
+    if (!IANAZone.isValidZone(timezone)) {
+      throw new ValidationError(`Unknown IANA timezone: ${timezone}`, [
+        { field: 'timezone', message: 'unknown zone' },
       ]);
     }
 

--- a/backend/src/api/routes/v1/preflight.ts
+++ b/backend/src/api/routes/v1/preflight.ts
@@ -1,0 +1,70 @@
+/**
+ * Pre-flight weather check — issue #351.
+ *
+ * Read-only. Deliberately separate from POST /models/run: it must be callable
+ * before the user has committed to anything, and it must never create state.
+ */
+
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { ValidationError } from '../../../domain/errors/index.js';
+import { preflightWeather } from '../../../application/services/WeatherPreflightService.js';
+import { parseIsoToDate } from '../../../shared/dateParsing.js';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /models/preflight:
+ *   post:
+ *     summary: Inspect a weather file before running a model
+ *     description: >
+ *       Detects the daily-only CFFDRS shape and, when found, returns the
+ *       starting codes already present in the file. Creates nothing.
+ *     responses:
+ *       200:
+ *         description: Inspection result
+ *       400:
+ *         description: Missing required field, or an unparseable CSV
+ */
+router.post('/models/preflight', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { timezone, timeRange, weather } = req.body ?? {};
+
+    if (typeof timezone !== 'string' || timezone.trim() === '') {
+      throw new ValidationError('timezone is required (IANA identifier)', [
+        { field: 'timezone', message: 'required' },
+      ]);
+    }
+
+    if (weather === null || typeof weather !== 'object') {
+      throw new ValidationError('weather config is required', [
+        { field: 'weather', message: 'required' },
+      ]);
+    }
+
+    // There is no separate ignition field on a run request — timeRange.start
+    // is the ignition instant. See #351.
+    const start = timeRange?.start;
+    if (typeof start !== 'string' || start.trim() === '') {
+      throw new ValidationError('timeRange.start is required — it is the ignition time', [
+        { field: 'timeRange.start', message: 'required' },
+      ]);
+    }
+
+    // parseIsoToDate is the house parser: it rejects bare timestamps that carry
+    // no UTC offset rather than guessing a zone for them.
+    let ignition: Date;
+    try {
+      ignition = parseIsoToDate(start, 'timeRange.start');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ValidationError(message, [{ field: 'timeRange.start', message: 'unparseable' }]);
+    }
+
+    res.json(await preflightWeather(weather, ignition, timezone));
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/application/services/ModelResultsService.ts
+++ b/backend/src/application/services/ModelResultsService.ts
@@ -27,6 +27,7 @@ import type {
 } from '../interfaces/index.js';
 import { createFireModelId } from '../../domain/entities/FireModel.js';
 import { readModelStartDate } from './modelStartDate.js';
+import { readFuelVintage, type FuelVintageRecord } from './fuelVintageRecord.js';
 
 /**
  * Execution summary for API response
@@ -82,6 +83,13 @@ export interface ModelInputs {
    * Absent when nothing on disk records it.
    */
   modelStartDate?: string;
+  /**
+   * The fuel vintage this run actually used, recorded when it ran (#331).
+   * Absent for runs that predate the recording — displayed as "not recorded"
+   * rather than re-resolved, because installing a year later must not rewrite
+   * what a past run claims.
+   */
+  fuelVintage?: FuelVintageRecord;
 }
 
 /**
@@ -371,6 +379,11 @@ export class ModelResultsService {
 
         // The year this fire was modelled for — drives fuel vintage display
         // in results (#319). Undefined when nothing on disk records it.
+        const fuelVintage = await readFuelVintage(simDir);
+        if (fuelVintage) {
+          inputs.fuelVintage = fuelVintage;
+        }
+
         const modelStartDate = await readModelStartDate(simDir);
         if (modelStartDate) {
           inputs.modelStartDate = modelStartDate.toISOString();

--- a/backend/src/application/services/WeatherContractCheck.ts
+++ b/backend/src/application/services/WeatherContractCheck.ts
@@ -1,0 +1,43 @@
+/**
+ * Pre-run weather contract check — issues #339, #340, #341.
+ *
+ * Resolves the weather exactly as the engine will, then checks it against
+ * FireSTARR's input contract BEFORE a model or job exists. A failure here is a
+ * 400 naming the problem, not a queued job that dies ten seconds later with the
+ * reason buried in the container log.
+ */
+
+import { getWeatherService } from '../../infrastructure/weather/WeatherService.js';
+import { validateFireStarrContract } from '../../infrastructure/firestarr/weatherContract.js';
+import { ValidationError } from '../../domain/errors/index.js';
+import type { WeatherConfig, WeatherLocation, WeatherDateRange } from '../interfaces/weather.js';
+
+/**
+ * @throws ValidationError when the weather cannot be resolved, or when it does
+ *         not satisfy the contract. Every problem is reported at once so the
+ *         user fixes them in one pass rather than one failed run at a time.
+ */
+export async function assertWeatherMeetsEngineContract(
+  weather: WeatherConfig,
+  ignition: Date,
+  timezone: string,
+  location: WeatherLocation,
+  dateRange: WeatherDateRange,
+): Promise<void> {
+  let points;
+  try {
+    points = await getWeatherService().resolveWeather({ ...weather, timezone }, location, dateRange);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(`The weather could not be read: ${message}`, [
+      { field: 'weather', message },
+    ]);
+  }
+
+  const result = validateFireStarrContract(points, ignition, timezone);
+  if (!result.valid) {
+    throw new ValidationError(result.issues.join(' '), [
+      { field: 'weather', message: result.issues.join(' ') },
+    ]);
+  }
+}

--- a/backend/src/application/services/WeatherContractCheck.ts
+++ b/backend/src/application/services/WeatherContractCheck.ts
@@ -34,7 +34,9 @@ export async function assertWeatherMeetsEngineContract(
     ]);
   }
 
-  const result = validateFireStarrContract(points, ignition, timezone);
+  // dateRange.end is timeRange.end — the contract applies to the simulated
+  // window, not to trailing weather the run never reaches (see #340 note).
+  const result = validateFireStarrContract(points, ignition, timezone, dateRange.end);
   if (!result.valid) {
     throw new ValidationError(result.issues.join(' '), [
       { field: 'weather', message: result.issues.join(' ') },

--- a/backend/src/application/services/WeatherPreflightService.ts
+++ b/backend/src/application/services/WeatherPreflightService.ts
@@ -1,0 +1,68 @@
+/**
+ * Pre-flight weather inspection — issue #351.
+ *
+ * Answers one question before a model exists: does this weather file have the
+ * daily-only CFFDRS shape, and if so what starting codes does it already
+ * contain? Creates nothing. No model, no job, no simulation directory — so a
+ * "no" from the user costs nothing to clean up.
+ */
+
+import { getWeatherService } from '../../infrastructure/weather/WeatherService.js';
+import {
+  hasDailyOnlyCffdrs,
+  findStartingCodeCandidate,
+  type StartingCodeCandidate,
+} from '../../infrastructure/weather/dailyCffdrs.js';
+import type { WeatherConfig } from '../interfaces/weather.js';
+import { ValidationError } from '../../domain/errors/index.js';
+
+export interface WeatherPreflightResult {
+  /** True only for the recoverable shape: some rows carry codes, others do not. */
+  dailyOnlyCffdrs: boolean;
+  /** The reading to offer, or null when none precedes ignition. Never invented. */
+  candidate: StartingCodeCandidate | null;
+}
+
+/**
+ * @param weather  the config as it would be submitted to /models/run
+ * @param ignition the model's start instant — timeRange.start, which is the
+ *                 only temporal anchor the request carries
+ * @param timezone IANA identifier, used to read the CSV's naive timestamps and
+ *                 to label the reading for a human
+ */
+export async function preflightWeather(
+  weather: WeatherConfig,
+  ignition: Date,
+  timezone: string,
+): Promise<WeatherPreflightResult> {
+  // Only firestarr_csv can have this shape. raw_weather carries explicit
+  // starting codes already, and spotwx is generated rather than uploaded.
+  if (weather.source !== 'firestarr_csv') {
+    return { dailyOnlyCffdrs: false, candidate: null };
+  }
+
+  let rows;
+  try {
+    rows = await getWeatherService().resolveWeather(
+      { ...weather, timezone },
+      // The firestarr_csv branch reads neither location nor dateRange —
+      // resolveWeather:78-94 forwards only content and timezone to
+      // parseFirestarrCsv. These are placeholders for a signature, not inputs.
+      { latitude: 0, longitude: 0 },
+      { start: ignition, end: ignition },
+    );
+  } catch (error) {
+    // A malformed file is the user's problem to see, not a 500.
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(`Could not parse the weather CSV: ${message}`);
+  }
+
+  if (!hasDailyOnlyCffdrs(rows)) {
+    return { dailyOnlyCffdrs: false, candidate: null };
+  }
+
+  return {
+    dailyOnlyCffdrs: true,
+    candidate: findStartingCodeCandidate(rows, ignition, timezone),
+  };
+}

--- a/backend/src/application/services/WeatherPreflightService.ts
+++ b/backend/src/application/services/WeatherPreflightService.ts
@@ -11,7 +11,9 @@ import { getWeatherService } from '../../infrastructure/weather/WeatherService.j
 import {
   hasDailyOnlyCffdrs,
   findStartingCodeCandidate,
+  describeDailyRhythm,
   type StartingCodeCandidate,
+  type DailyRhythm,
 } from '../../infrastructure/weather/dailyCffdrs.js';
 import type { WeatherConfig } from '../interfaces/weather.js';
 import { ValidationError } from '../../domain/errors/index.js';
@@ -21,6 +23,13 @@ export interface WeatherPreflightResult {
   dailyOnlyCffdrs: boolean;
   /** The reading to offer, or null when none precedes ignition. Never invented. */
   candidate: StartingCodeCandidate | null;
+  /**
+   * How the file's daily rhythm compares with the contract — the Date column is
+   * local time in the model's timezone, and daily codes are recorded at noon
+   * (#354). Null for a conforming file, which has no daily rhythm to measure
+   * because every row carries codes.
+   */
+  rhythm: DailyRhythm | null;
 }
 
 /**
@@ -38,7 +47,7 @@ export async function preflightWeather(
   // Only firestarr_csv can have this shape. raw_weather carries explicit
   // starting codes already, and spotwx is generated rather than uploaded.
   if (weather.source !== 'firestarr_csv') {
-    return { dailyOnlyCffdrs: false, candidate: null };
+    return { dailyOnlyCffdrs: false, candidate: null, rhythm: null };
   }
 
   let rows;
@@ -58,11 +67,14 @@ export async function preflightWeather(
   }
 
   if (!hasDailyOnlyCffdrs(rows)) {
-    return { dailyOnlyCffdrs: false, candidate: null };
+    return { dailyOnlyCffdrs: false, candidate: null, rhythm: null };
   }
 
   return {
     dailyOnlyCffdrs: true,
     candidate: findStartingCodeCandidate(rows, ignition, timezone),
+    // Only meaningful for a daily-only file. When every row carries codes there
+    // is no rhythm to measure — every hour looks like the daily reading.
+    rhythm: describeDailyRhythm(rows, timezone),
   };
 }

--- a/backend/src/application/services/__tests__/fuelVintageRecord.test.ts
+++ b/backend/src/application/services/__tests__/fuelVintageRecord.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Reading the recorded fuel vintage — issue #331.
+ *
+ * Results must read what was written when the model ran, never re-resolve.
+ * Where nothing was recorded — every run that predates #331 — the answer is
+ * "not recorded", not a guess made today.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { readFuelVintage } from '../fuelVintageRecord.js';
+
+describe('readFuelVintage', () => {
+  let simDir: string;
+
+  beforeEach(async () => {
+    simDir = await mkdtemp(join(tmpdir(), 'fuel-vintage-read-'));
+  });
+
+  afterEach(async () => {
+    await rm(simDir, { recursive: true, force: true });
+  });
+
+  async function write(contents: unknown): Promise<void> {
+    await writeFile(join(simDir, 'fuel-vintage.json'), JSON.stringify(contents), 'utf-8');
+  }
+
+  it('returns what the run recorded', async () => {
+    await write({
+      requestedYear: 2024,
+      vintage: '2024',
+      matchedRequestedYear: true,
+      usedFallback: false,
+      gridPath: '/data/generated/grid/100m/2024/fuel_11_0.tif',
+      recordedAt: '2026-08-19T12:00:00.000Z',
+    });
+
+    const record = await readFuelVintage(simDir);
+
+    expect(record?.vintage).toBe('2024');
+    expect(record?.requestedYear).toBe(2024);
+    expect(record?.usedFallback).toBe(false);
+  });
+
+  it('preserves the admission that a default dataset was substituted', async () => {
+    await write({
+      requestedYear: 2024,
+      vintage: 'default',
+      matchedRequestedYear: false,
+      usedFallback: true,
+      gridPath: '/data/generated/grid/100m/default/fuel_11_0.tif',
+      recordedAt: '2026-08-19T12:00:00.000Z',
+    });
+
+    const record = await readFuelVintage(simDir);
+    expect(record?.usedFallback).toBe(true);
+    expect(record?.vintage).toBe('default');
+  });
+
+  it('returns undefined for a run that predates the recording', async () => {
+    // Must NOT infer one. Installing 2024 tomorrow cannot change what a run
+    // from last year used.
+    expect(await readFuelVintage(simDir)).toBeUndefined();
+  });
+
+  it('returns undefined rather than throwing on an unreadable record', async () => {
+    await writeFile(join(simDir, 'fuel-vintage.json'), 'not json at all', 'utf-8');
+    expect(await readFuelVintage(simDir)).toBeUndefined();
+  });
+
+  it('returns undefined when the record is missing its vintage', async () => {
+    await write({ requestedYear: 2024 });
+    expect(await readFuelVintage(simDir)).toBeUndefined();
+  });
+});

--- a/backend/src/application/services/fuelVintageRecord.ts
+++ b/backend/src/application/services/fuelVintageRecord.ts
@@ -1,0 +1,60 @@
+/**
+ * Reading the fuel vintage a completed run recorded — issue #331.
+ *
+ * The results view used to call resolveForYear() when the page was viewed, so
+ * installing a fuel year later retroactively rewrote what past runs claimed to
+ * have used. A finished run is a record of what happened.
+ *
+ * Nothing here infers or falls back. A run with no record reads as "not
+ * recorded", which is the truth, rather than today's answer to a question that
+ * was asked long ago.
+ */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+export interface FuelVintageRecord {
+  /** The year the model was run FOR. */
+  requestedYear: number;
+  /** The vintage directory actually used — "2024", "default". */
+  vintage: string;
+  /** Whether that vintage matched the requested year. */
+  matchedRequestedYear: boolean;
+  /** Whether a default dataset stood in for a missing year. */
+  usedFallback: boolean;
+  /** The exact grid file used, for tracing. */
+  gridPath?: string;
+  /** When the run wrote this down. */
+  recordedAt?: string;
+}
+
+/** Returns undefined when nothing was recorded, or the record is unusable. */
+export async function readFuelVintage(simDir: string): Promise<FuelVintageRecord | undefined> {
+  let raw: string;
+  try {
+    raw = await readFile(join(simDir, 'fuel-vintage.json'), 'utf-8');
+  } catch {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<FuelVintageRecord>;
+
+    // A record without a vintage answers nothing; treat it as absent rather
+    // than surfacing a half-answer that reads as fact.
+    if (typeof parsed.vintage !== 'string' || typeof parsed.requestedYear !== 'number') {
+      return undefined;
+    }
+
+    return {
+      requestedYear: parsed.requestedYear,
+      vintage: parsed.vintage,
+      matchedRequestedYear: parsed.matchedRequestedYear === true,
+      usedFallback: parsed.usedFallback === true,
+      gridPath: parsed.gridPath,
+      recordedAt: parsed.recordedAt,
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/backend/src/infrastructure/firestarr/FireSTARRInputGenerator.ts
+++ b/backend/src/infrastructure/firestarr/FireSTARRInputGenerator.ts
@@ -204,6 +204,60 @@ export class FireSTARRInputGenerator implements IInputGenerator<FireSTARRParams>
     );
   }
 
+  /**
+   * The vintage directory a resolved grid path sits in — "2024", "default".
+   *
+   * The layout is {gridRoot}/{vintage}/fuel_*.tif, so the segment immediately
+   * below the grid root IS the vintage. Derived from the path actually used
+   * rather than re-asked, so the record cannot disagree with the run.
+   */
+  private vintageFromGridPath(gridPath: string): string | undefined {
+    if (!this.config.gridRoot) return undefined;
+
+    const relative = gridPath.startsWith(this.config.gridRoot)
+      ? gridPath.slice(this.config.gridRoot.length)
+      : undefined;
+    if (relative === undefined) return undefined;
+
+    const [segment] = relative.split(/[\\/]/).filter(Boolean);
+    return segment;
+  }
+
+  /**
+   * Records the fuel vintage this run actually used — issue #331.
+   *
+   * The results view used to resolve the vintage when the page was VIEWED, so
+   * installing a fuel year later retroactively rewrote what past runs claimed.
+   * A completed run is a record of what happened; writing the answer down at
+   * the moment it is true is the only way it stays true.
+   */
+  private async recordFuelVintage(
+    workingDir: string,
+    gridPath: string,
+    requestedYear: number,
+  ): Promise<void> {
+    const vintage = this.vintageFromGridPath(gridPath);
+    const matchedRequestedYear = vintage === String(requestedYear);
+
+    const record = {
+      requestedYear,
+      vintage: vintage ?? null,
+      matchedRequestedYear,
+      usedFallback: !matchedRequestedYear,
+      gridPath,
+      recordedAt: new Date().toISOString(),
+    };
+
+    try {
+      await writeFile(join(workingDir, 'fuel-vintage.json'), JSON.stringify(record, null, 2), 'utf-8');
+    } catch (error) {
+      // Never fail a run because the audit note could not be written; the run
+      // itself is the valuable thing. It will read as "not recorded" later.
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[FireSTARRInputGenerator] Could not record fuel vintage: ${message}`);
+    }
+  }
+
   async generate(
     modelId: FireModelId,
     params: FireSTARRParams
@@ -239,6 +293,9 @@ export class FireSTARRInputGenerator implements IInputGenerator<FireSTARRParams>
       if (!fuelGrid) {
         return Result.fail(new ValidationError(await this.describeMissingFuel(modelYear)));
       }
+
+      // Write down which vintage this run used, now, while it is true (#331).
+      await this.recordFuelVintage(workingDir, fuelGrid, modelYear);
 
       // Write weather CSV
       const weatherFile = join(workingDir, 'weather.csv');

--- a/backend/src/infrastructure/firestarr/FireSTARRInputGenerator.ts
+++ b/backend/src/infrastructure/firestarr/FireSTARRInputGenerator.ts
@@ -170,6 +170,40 @@ export class FireSTARRInputGenerator implements IInputGenerator<FireSTARRParams>
     }
   }
 
+  /** Vintage directories actually present under the grid root, e.g. ["2023", "2026", "default"]. */
+  private async listInstalledVintages(): Promise<string[]> {
+    if (!this.config.gridRoot) return [];
+    try {
+      const entries = await readdir(this.config.gridRoot, { withFileTypes: true });
+      return entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort();
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Says which fuel dataset is missing and what to do — issue #330.
+   *
+   * Naming the vintages that ARE installed turns the message from a refusal
+   * into a choice: install the missing year, or model a year you already have.
+   */
+  private async describeMissingFuel(modelYear: number): Promise<string> {
+    const installed = await this.listInstalledVintages();
+
+    const available = installed.length > 0
+      ? `Installed fuel datasets: ${installed.join(', ')}.`
+      : 'No fuel datasets are installed at all.';
+
+    return (
+      `No fuel dataset covers this ignition for ${modelYear}. ${available} ` +
+      `Install the ${modelYear} fuel dataset (or a default dataset), or set the model start ` +
+      `date to a year you already have. The model was not started.`
+    );
+  }
+
   async generate(
     modelId: FireModelId,
     params: FireSTARRParams
@@ -189,6 +223,21 @@ export class FireSTARRInputGenerator implements IInputGenerator<FireSTARRParams>
         return Result.fail(
           new ValidationError(`Weather data validation failed: ${validation.issues.join('; ')}`)
         );
+      }
+
+      // Fuel coverage must resolve BEFORE a container is launched (#330).
+      // This lookup already knew the answer — it logged "No fuel grid found
+      // containing coordinates" and carried on, so the user's only signal was
+      // "Process exited with code 1" after the engine died on a bare raster
+      // root. Reported here, while it can still be acted on.
+      const modelYear = params.startDate.getFullYear();
+      const fuelGrid = await this.findFuelGridForCoordinates(
+        params.latitude,
+        params.longitude,
+        modelYear,
+      );
+      if (!fuelGrid) {
+        return Result.fail(new ValidationError(await this.describeMissingFuel(modelYear)));
       }
 
       // Write weather CSV

--- a/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
+++ b/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
@@ -147,6 +147,28 @@ export function validateWeatherData(weatherData: WeatherHourlyData[]): {
   for (let i = 0; i < weatherData.length; i++) {
     const w = weatherData[i];
 
+    // Finiteness must be checked BEFORE any range check. Every comparison with
+    // NaN is false, so `w.ffmc < 0 || w.ffmc > 101` calls NaN valid. That is how
+    // NaN reached FireSTARR on 2026-08-17 and segfaulted it (exit 139). See #350.
+    const numericFields: Array<[string, number]> = [
+      ['temp', w.temp],
+      ['rh', w.rh],
+      ['ws', w.ws],
+      ['wd', w.wd],
+      ['precip', w.precip],
+      ['ffmc', w.ffmc],
+      ['dmc', w.dmc],
+      ['dc', w.dc],
+      ['isi', w.isi],
+      ['bui', w.bui],
+      ['fwi', w.fwi],
+    ];
+    for (const [name, value] of numericFields) {
+      if (!Number.isFinite(value)) {
+        issues.push(`Row ${i}: ${name} is ${value} — not a finite number`);
+      }
+    }
+
     if (w.rh < 0 || w.rh > 100) {
       issues.push(`Row ${i}: RH ${w.rh} out of range [0-100]`);
     }

--- a/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
+++ b/backend/src/infrastructure/firestarr/WeatherCSVWriter.ts
@@ -121,6 +121,85 @@ export async function writeWeatherCSV(
  * @param weatherData - Array of weather observations
  * @returns Validation result with any issues found
  */
+/** At most this many example row numbers per grouped issue. */
+const MAX_EXAMPLE_ROWS = 5;
+/** At most this many distinct gap sizes named in the distribution. */
+const MAX_GAP_KINDS = 5;
+
+/** "rows 3, 8, 12 and 240 more" — enough to go and look without listing everything. */
+function describeRows(rows: number[]): string {
+  const shown = rows.slice(0, MAX_EXAMPLE_ROWS).join(', ');
+  const rest = rows.length - Math.min(rows.length, MAX_EXAMPLE_ROWS);
+  return rest > 0 ? `rows ${shown} and ${rest} more` : `row${rows.length > 1 ? 's' : ''} ${shown}`;
+}
+
+/**
+ * Summarises the hourly-continuity failures — issue #342.
+ *
+ * One issue per observation pair produced a 355 KB message with 5,928 lines on
+ * the CIFFC demo, and the single sentence that mattered — the file is daily
+ * observations in reverse chronological order — was buried in it. The gap
+ * DISTRIBUTION carries that conclusion, so report the distribution and state the
+ * conclusion outright.
+ */
+function summariseGaps(weatherData: WeatherHourlyData[]): string[] {
+  const countByGap = new Map<number, number>();
+  let offending = 0;
+
+  for (let i = 1; i < weatherData.length; i++) {
+    const hourDiff =
+      (weatherData[i].date.getTime() - weatherData[i - 1].date.getTime()) / (1000 * 60 * 60);
+
+    if (Math.abs(hourDiff - 1) > 0.1) {
+      offending += 1;
+      const rounded = Math.round(hourDiff * 10) / 10;
+      countByGap.set(rounded, (countByGap.get(rounded) ?? 0) + 1);
+    }
+  }
+
+  if (offending === 0) return [];
+
+  const ranked = [...countByGap.entries()].sort((a, b) => b[1] - a[1]);
+  const distribution = ranked
+    .slice(0, MAX_GAP_KINDS)
+    .map(([gap, count]) => `${gap}h x${count}`)
+    .join(', ');
+  const omitted = ranked.length - Math.min(ranked.length, MAX_GAP_KINDS);
+
+  const parts = [
+    `${offending} observation${offending > 1 ? 's are' : ' is'} not one hour after the previous one. ` +
+      `Gap distribution: ${distribution}${omitted > 0 ? `, and ${omitted} other gap sizes` : ''}.`,
+  ];
+
+  // State the conclusion rather than leaving it to be inferred from the counts.
+  const allNegative = ranked.every(([gap]) => gap < 0);
+  const mostlyDaily = ranked[0] !== undefined && Math.abs(Math.abs(ranked[0][0]) - 24) < 0.5;
+
+  if (allNegative && mostlyDaily) {
+    parts.push(
+      'These are daily steps running backwards, so the file is in reverse chronological order ' +
+        '(newest first) at daily resolution. FireSTARR needs hourly observations in ascending order.',
+    );
+  } else if (allNegative) {
+    parts.push(
+      'Every gap is negative, so the observations are in reverse chronological order (newest first). ' +
+        'FireSTARR needs them ascending.',
+    );
+  } else if (mostlyDaily) {
+    parts.push('These are daily steps. FireSTARR needs hourly observations.');
+  }
+
+  return parts;
+}
+
+/**
+ * Validates a weather series for FireSTARR.
+ *
+ * Reporting is GROUPED, not per row (#342). Every problem is still detected;
+ * they are collapsed by field and by gap size so the message stays small enough
+ * to store in jobs.error and ship to a browser, and so the diagnosis survives
+ * being read by a human.
+ */
 export function validateWeatherData(weatherData: WeatherHourlyData[]): {
   valid: boolean;
   issues: string[];
@@ -132,18 +211,19 @@ export function validateWeatherData(weatherData: WeatherHourlyData[]): {
     return { valid: false, issues };
   }
 
-  // Check for required hourly coverage
-  for (let i = 1; i < weatherData.length; i++) {
-    const prev = weatherData[i - 1].date.getTime();
-    const curr = weatherData[i].date.getTime();
-    const hourDiff = (curr - prev) / (1000 * 60 * 60);
+  issues.push(...summariseGaps(weatherData));
 
-    if (Math.abs(hourDiff - 1) > 0.1) {
-      issues.push(`Non-hourly gap between observations ${i - 1} and ${i}: ${hourDiff} hours`);
-    }
-  }
+  // Collect per-row problems keyed by what is wrong, so 500 broken rows become
+  // one line per field rather than 500 lines.
+  const nonFinite = new Map<string, number[]>();
+  const outOfRange = new Map<string, number[]>();
 
-  // Validate value ranges
+  const record = (bucket: Map<string, number[]>, key: string, row: number): void => {
+    const rows = bucket.get(key);
+    if (rows) rows.push(row);
+    else bucket.set(key, [row]);
+  };
+
   for (let i = 0; i < weatherData.length; i++) {
     const w = weatherData[i];
 
@@ -164,26 +244,24 @@ export function validateWeatherData(weatherData: WeatherHourlyData[]): {
       ['fwi', w.fwi],
     ];
     for (const [name, value] of numericFields) {
-      if (!Number.isFinite(value)) {
-        issues.push(`Row ${i}: ${name} is ${value} — not a finite number`);
-      }
+      if (!Number.isFinite(value)) record(nonFinite, name, i);
     }
 
-    if (w.rh < 0 || w.rh > 100) {
-      issues.push(`Row ${i}: RH ${w.rh} out of range [0-100]`);
-    }
-    if (w.wd < 0 || w.wd > 360) {
-      issues.push(`Row ${i}: Wind direction ${w.wd} out of range [0-360]`);
-    }
-    if (w.ffmc < 0 || w.ffmc > 101) {
-      issues.push(`Row ${i}: FFMC ${w.ffmc} out of range [0-101]`);
-    }
-    if (w.ws < 0) {
-      issues.push(`Row ${i}: Wind speed ${w.ws} is negative`);
-    }
-    if (w.precip < 0) {
-      issues.push(`Row ${i}: Precipitation ${w.precip} is negative`);
-    }
+    if (w.rh < 0 || w.rh > 100) record(outOfRange, 'RH must be within [0-100]', i);
+    if (w.wd < 0 || w.wd > 360) record(outOfRange, 'Wind direction must be within [0-360]', i);
+    if (w.ffmc < 0 || w.ffmc > 101) record(outOfRange, 'FFMC must be within [0-101]', i);
+    if (w.ws < 0) record(outOfRange, 'Wind speed must not be negative', i);
+    if (w.precip < 0) record(outOfRange, 'Precipitation must not be negative', i);
+  }
+
+  for (const [field, rows] of nonFinite) {
+    issues.push(
+      `${field} is not a finite number on ${rows.length} row${rows.length > 1 ? 's' : ''} (${describeRows(rows)}).`,
+    );
+  }
+
+  for (const [rule, rows] of outOfRange) {
+    issues.push(`${rule} — breached on ${rows.length} row${rows.length > 1 ? 's' : ''} (${describeRows(rows)}).`);
   }
 
   return { valid: issues.length === 0, issues };

--- a/backend/src/infrastructure/firestarr/__tests__/FireSTARRInputGenerator.fuelDataset.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/FireSTARRInputGenerator.fuelDataset.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Missing fuel dataset is reported, not discovered by the engine — issue #330.
+ *
+ * A model whose year has no installed fuel dataset failed with:
+ *
+ *   Model Execution: Failed
+ *   Process exited with code 1
+ *
+ * The system knew, twice over, before the container was ever launched: the
+ * input generator logged "No fuel grid found containing coordinates" and
+ * carried on, and the fuel dataset catalog had already resolved that year to
+ * nothing. Both were discarded and the user got an exit code.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, rm, mkdir } from 'fs/promises';
+import { tmpdir } from 'os';
+import { FireSTARRInputGenerator } from '../FireSTARRInputGenerator.js';
+import { createFireModelId } from '../../../domain/entities/FireModel.js';
+import type { FireSTARRParams, WeatherHourlyData } from '../types.js';
+
+/** Hay River, NWT — the location from the report. */
+const LAT = 60.823286;
+const LON = -115.704839;
+
+function weather(hours = 26): WeatherHourlyData[] {
+  const base = new Date('2024-06-19T12:00:00Z').getTime();
+  return Array.from({ length: hours }, (_, i) => ({
+    date: new Date(base + i * 3600000),
+    temp: 20, rh: 45, ws: 10, wd: 180, precip: 0,
+    ffmc: 85, dmc: 30, dc: 200, isi: 5, bui: 40, fwi: 10,
+  })) as WeatherHourlyData[];
+}
+
+function params(year: number): FireSTARRParams {
+  return {
+    latitude: LAT,
+    longitude: LON,
+    startDate: new Date(`${year}-06-19T12:00:00Z`),
+    startTime: '12:00',
+    timezone: 'America/Edmonton',
+    weatherData: weather(),
+    previousFFMC: 85,
+    previousDMC: 30,
+    previousDC: 200,
+  } as FireSTARRParams;
+}
+
+describe('FireSTARRInputGenerator — missing fuel dataset (#330)', () => {
+  let tempDir: string;
+  let gridRoot: string;
+  let generator: FireSTARRInputGenerator;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'firestarr-fuel-test-'));
+    gridRoot = join(tempDir, 'generated', 'grid', '100m');
+    // Two vintages installed, exactly as in the report: 2023 and 2026.
+    await mkdir(join(gridRoot, '2023'), { recursive: true });
+    await mkdir(join(gridRoot, '2026'), { recursive: true });
+
+    generator = new FireSTARRInputGenerator({
+      simsBasePath: join(tempDir, 'sims'),
+      gridRoot,
+    });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('fails before launching anything when the model year has no fuel coverage', async () => {
+    const result = await generator.generate(createFireModelId('fuel-330'), params(2024));
+    expect(result.success).toBe(false);
+  });
+
+  it('names the year the user actually asked for', async () => {
+    const result = await generator.generate(createFireModelId('fuel-330-year'), params(2024));
+    expect(String((result as { error?: { message?: string } }).error?.message)).toMatch(/2024/);
+  });
+
+  it('says what to do about it rather than only that it failed', async () => {
+    const result = await generator.generate(createFireModelId('fuel-330-fix'), params(2024));
+    const message = String((result as { error?: { message?: string } }).error?.message);
+
+    expect(message).toMatch(/fuel/i);
+    expect(message).toMatch(/install/i);
+  });
+
+  it('lists the vintages that ARE installed, so the choice is obvious', async () => {
+    const result = await generator.generate(createFireModelId('fuel-330-list'), params(2024));
+    const message = String((result as { error?: { message?: string } }).error?.message);
+
+    expect(message).toMatch(/2023/);
+    expect(message).toMatch(/2026/);
+  });
+
+  it('never mentions an exit code — that was the useless part', async () => {
+    const result = await generator.generate(createFireModelId('fuel-330-noexit'), params(2024));
+    const message = String((result as { error?: { message?: string } }).error?.message);
+
+    expect(message).not.toMatch(/exit code/i);
+  });
+});

--- a/backend/src/infrastructure/firestarr/__tests__/FireSTARRInputGenerator.recordVintage.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/FireSTARRInputGenerator.recordVintage.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The fuel vintage is RECORDED when the model runs — issue #331.
+ *
+ * The results view resolved the vintage when the page was viewed, so installing
+ * a fuel year later retroactively rewrote what past runs claimed to have used.
+ * A historical run is a record of what happened; it must not change because the
+ * machine changed afterwards.
+ *
+ * The generator already resolves the grid path (it must, since #330), so the
+ * answer is in hand at exactly the moment it is true.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, rm, mkdir, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { FireSTARRInputGenerator } from '../FireSTARRInputGenerator.js';
+import { createFireModelId } from '../../../domain/entities/FireModel.js';
+import type { FireSTARRParams, WeatherHourlyData } from '../types.js';
+
+const LAT = 60.823286;
+const LON = -115.704839;
+
+function weather(): WeatherHourlyData[] {
+  const base = new Date('2024-06-19T12:00:00Z').getTime();
+  return Array.from({ length: 26 }, (_, i) => ({
+    date: new Date(base + i * 3600000),
+    temp: 20, rh: 45, ws: 10, wd: 180, precip: 0,
+    ffmc: 85, dmc: 30, dc: 200, isi: 5, bui: 40, fwi: 10,
+  })) as WeatherHourlyData[];
+}
+
+function params(year: number): FireSTARRParams {
+  return {
+    latitude: LAT,
+    longitude: LON,
+    startDate: new Date(`${year}-06-19T12:00:00Z`),
+    startTime: '12:00',
+    timezone: 'America/Edmonton',
+    weatherData: weather(),
+    previousFFMC: 85,
+    previousDMC: 30,
+    previousDC: 200,
+  } as FireSTARRParams;
+}
+
+describe('FireSTARRInputGenerator records the fuel vintage (#331)', () => {
+  let tempDir: string;
+  let gridRoot: string;
+  let simsBasePath: string;
+  let generator: FireSTARRInputGenerator;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'firestarr-vintage-test-'));
+    gridRoot = join(tempDir, 'generated', 'grid', '100m');
+    simsBasePath = join(tempDir, 'sims');
+    await mkdir(join(gridRoot, '2024'), { recursive: true });
+    await mkdir(join(gridRoot, 'default'), { recursive: true });
+
+    generator = new FireSTARRInputGenerator({ simsBasePath, gridRoot });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  async function recordedFor(modelId: string, gridPath: string, year: number) {
+    vi.spyOn(generator, 'findFuelGridForCoordinates').mockResolvedValue(gridPath);
+
+    const result = await generator.generate(createFireModelId(modelId), params(year));
+    expect(result.success).toBe(true);
+
+    const raw = await readFile(join(simsBasePath, modelId, 'fuel-vintage.json'), 'utf-8');
+    return JSON.parse(raw);
+  }
+
+  it('records the vintage that was actually used', async () => {
+    const recorded = await recordedFor('vintage-match', join(gridRoot, '2024', 'fuel_11_0.tif'), 2024);
+
+    expect(recorded.vintage).toBe('2024');
+    expect(recorded.requestedYear).toBe(2024);
+    expect(recorded.matchedRequestedYear).toBe(true);
+    expect(recorded.usedFallback).toBe(false);
+  });
+
+  it('records that a default dataset stood in for a missing year', async () => {
+    // The silent {year}/ -> default/ fallback is exactly what a historical run
+    // needs to admit to, since the output depends on it.
+    const recorded = await recordedFor('vintage-fallback', join(gridRoot, 'default', 'fuel_11_0.tif'), 2024);
+
+    expect(recorded.vintage).toBe('default');
+    expect(recorded.requestedYear).toBe(2024);
+    expect(recorded.matchedRequestedYear).toBe(false);
+    expect(recorded.usedFallback).toBe(true);
+  });
+
+  it('records the grid path, so the exact file used is traceable', async () => {
+    const gridPath = join(gridRoot, '2024', 'fuel_11_0.tif');
+    const recorded = await recordedFor('vintage-path', gridPath, 2024);
+
+    expect(recorded.gridPath).toBe(gridPath);
+  });
+
+  it('records when the run happened, not when it is read', async () => {
+    const recorded = await recordedFor('vintage-when', join(gridRoot, '2024', 'fuel_11_0.tif'), 2024);
+    expect(Date.parse(recorded.recordedAt)).not.toBeNaN();
+  });
+});

--- a/backend/src/infrastructure/firestarr/__tests__/WeatherCSVWriter.bounded.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/WeatherCSVWriter.bounded.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Bounded weather validation reporting — issue #342.
+ *
+ * A real failure on the CIFFC demo produced a 355 KB error containing 5,928
+ * issues, one line per observation pair, written to jobs.error and shipped to
+ * the browser. The validation was correct; the reporting destroyed its value.
+ *
+ * The underlying problem was one sentence long — the file is daily observations
+ * in reverse chronological order — and that conclusion was derivable from the
+ * distribution of the gaps. Nobody reads to line 5,928.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateWeatherData } from '../WeatherCSVWriter.js';
+import type { WeatherHourlyData } from '../types.js';
+
+const BASE = new Date('2026-08-04T12:00:00Z').getTime();
+const HOUR = 60 * 60 * 1000;
+
+function point(offsetHours: number, overrides: Partial<WeatherHourlyData> = {}): WeatherHourlyData {
+  return {
+    date: new Date(BASE + offsetHours * HOUR),
+    temp: 20, rh: 45, ws: 10, wd: 180, precip: 0,
+    ffmc: 85, dmc: 30, dc: 200, isi: 5, bui: 40, fwi: 10,
+    ...overrides,
+  } as WeatherHourlyData;
+}
+
+/** Hourly ascending — the shape FireSTARR requires. */
+function hourly(count: number): WeatherHourlyData[] {
+  return Array.from({ length: count }, (_, i) => point(i));
+}
+
+/** Daily observations in reverse chronological order — the demo failure. */
+function dailyDescending(count: number): WeatherHourlyData[] {
+  return Array.from({ length: count }, (_, i) => point(-24 * i));
+}
+
+describe('validateWeatherData reporting is bounded (#342)', () => {
+  it('still accepts correct data', () => {
+    const result = validateWeatherData(hourly(48));
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  describe('the demo failure: 5,928 gap issues', () => {
+    const result = validateWeatherData(dailyDescending(3000));
+
+    it('is still reported as invalid', () => {
+      expect(result.valid).toBe(false);
+    });
+
+    it('produces a handful of issues, not one per observation pair', () => {
+      expect(result.issues.length).toBeLessThanOrEqual(5);
+    });
+
+    it('produces a message small enough to store and transport', () => {
+      // 355 KB went into jobs.error and over the API. This must be orders of
+      // magnitude smaller regardless of how broken the file is.
+      expect(result.issues.join(' ').length).toBeLessThan(2000);
+    });
+
+    it('states how many observations are affected', () => {
+      expect(result.issues.join(' ')).toMatch(/2999|2,999/);
+    });
+
+    it('names the dominant gap instead of repeating it 2,999 times', () => {
+      expect(result.issues.join(' ')).toMatch(/-24/);
+    });
+
+    it('draws the conclusion the user needs — reverse chronological order', () => {
+      // The insight was always derivable. Now it is stated.
+      expect(result.issues.join(' ')).toMatch(/reverse|descending|newest first/i);
+    });
+  });
+
+  it('summarises a mixture of gaps with counts rather than listing each', () => {
+    // Ascending but with holes: a few 2-hour and 3-hour jumps.
+    const points = [point(0), point(1), point(3), point(4), point(7), point(8), point(10)];
+    const result = validateWeatherData(points);
+
+    expect(result.issues.length).toBeLessThanOrEqual(3);
+    expect(result.issues.join(' ')).toMatch(/gap/i);
+  });
+
+  it('groups non-finite values by field instead of one issue per row', () => {
+    const points = hourly(500).map((p) => ({ ...p, ffmc: NaN, dmc: NaN }));
+    const result = validateWeatherData(points);
+
+    expect(result.valid).toBe(false);
+    // Two fields affected — two issues, not a thousand.
+    expect(result.issues.length).toBeLessThanOrEqual(4);
+    expect(result.issues.join(' ')).toMatch(/500/);
+    expect(result.issues.join(' ')).toMatch(/ffmc/);
+    expect(result.issues.join(' ')).toMatch(/dmc/);
+  });
+
+  it('gives example row numbers so the user can go and look', () => {
+    const points = hourly(100).map((p, i) => (i === 7 ? { ...p, rh: 250 } : p));
+    const result = validateWeatherData(points);
+
+    expect(result.issues.join(' ')).toMatch(/\b7\b/);
+  });
+
+  it('groups out-of-range values by field too', () => {
+    const points = hourly(300).map((p) => ({ ...p, rh: 250 }));
+    const result = validateWeatherData(points);
+
+    expect(result.issues.length).toBeLessThanOrEqual(3);
+    expect(result.issues.join(' ')).toMatch(/300/);
+  });
+
+  it('stays bounded when everything is wrong at once', () => {
+    const points = dailyDescending(2000).map((p) => ({ ...p, ffmc: NaN, rh: -5, ws: -1 }));
+    const result = validateWeatherData(points);
+
+    expect(result.issues.join(' ').length).toBeLessThan(3000);
+  });
+});

--- a/backend/src/infrastructure/firestarr/__tests__/WeatherCSVWriter.finite.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/WeatherCSVWriter.finite.test.ts
@@ -1,0 +1,93 @@
+/**
+ * WeatherCSVWriter — validateWeatherData must reject non-finite numbers
+ *
+ * Issue #350. Every comparison with NaN is false, so the range checks that
+ * exist to catch invalid FWI values pass the one value that is definitely
+ * invalid. On 2026-08-17 this wrote NaN into weather.csv on 271 of 282 rows,
+ * validation passed, and FireSTARR segfaulted (exit 139).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateWeatherData } from '../WeatherCSVWriter.js';
+import type { WeatherHourlyData } from '../types.js';
+
+/** A fully valid hour. Callers override single fields to isolate one failure. */
+function hour(overrides: Partial<WeatherHourlyData> = {}): WeatherHourlyData {
+  return {
+    date: new Date('2026-08-01T00:00:00Z'),
+    temp: 24.4,
+    rh: 46,
+    ws: 10.2,
+    wd: 222,
+    precip: 0,
+    ffmc: 81.66,
+    dmc: 19.22,
+    dc: 412.67,
+    isi: 2,
+    bui: 34.44,
+    fwi: 4.64,
+    ...overrides,
+  };
+}
+
+/** Consecutive hours, so the hourly-gap check never fires and we isolate finiteness. */
+function hours(...overrides: Array<Partial<WeatherHourlyData>>): WeatherHourlyData[] {
+  const start = Date.UTC(2026, 7, 1, 0, 0, 0);
+  return overrides.map((o, i) =>
+    hour({ date: new Date(start + i * 3600_000), ...o })
+  );
+}
+
+describe('validateWeatherData — non-finite values', () => {
+  it('accepts fully valid finite data (guards against over-triggering)', () => {
+    const result = validateWeatherData(hours({}, {}, {}));
+    expect(result.issues).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  const NUMERIC_FIELDS = [
+    'temp', 'rh', 'ws', 'wd', 'precip',
+    'ffmc', 'dmc', 'dc', 'isi', 'bui', 'fwi',
+  ] as const;
+
+  for (const field of NUMERIC_FIELDS) {
+    it(`rejects NaN in ${field}`, () => {
+      const result = validateWeatherData(hours({ [field]: NaN }));
+      expect(result.valid).toBe(false);
+      expect(result.issues.join(' ')).toContain(field);
+    });
+
+    it(`rejects Infinity in ${field}`, () => {
+      const result = validateWeatherData(hours({ [field]: Infinity }));
+      expect(result.valid).toBe(false);
+      expect(result.issues.join(' ')).toContain(field);
+    });
+
+    it(`rejects -Infinity in ${field}`, () => {
+      const result = validateWeatherData(hours({ [field]: -Infinity }));
+      expect(result.valid).toBe(false);
+      expect(result.issues.join(' ')).toContain(field);
+    });
+  }
+
+  it("rejects vita's real failing row — valid observations, NaN indices", () => {
+    // 0,2026-08-01 00:06:00,0,24.4,46,10.2,222,NaN,NaN,NaN,NaN,NaN,NaN
+    const result = validateWeatherData(
+      hours({
+        ffmc: NaN, dmc: NaN, dc: NaN, isi: NaN, bui: NaN, fwi: NaN,
+      })
+    );
+
+    expect(result.valid).toBe(false);
+    // All six must be named — a person needs to know which columns are missing.
+    for (const field of ['ffmc', 'dmc', 'dc', 'isi', 'bui', 'fwi']) {
+      expect(result.issues.join(' ')).toContain(field);
+    }
+  });
+
+  it('reports the row index so a person can find the bad row', () => {
+    const result = validateWeatherData(hours({}, {}, { ffmc: NaN }));
+    expect(result.valid).toBe(false);
+    expect(result.issues.join(' ')).toContain('2');
+  });
+});

--- a/backend/src/infrastructure/firestarr/__tests__/weatherContract.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/weatherContract.test.ts
@@ -40,6 +40,54 @@ function hours(day: string, from: number, to: number): WeatherDataPoint[] {
 
 const NOON = at('2026-08-04 12:00:00');
 
+describe('validateFireStarrContract — the simulated window, not the whole file', () => {
+  // Regression: the check demanded a noon record on EVERY day present in the
+  // file, including partial days the simulation never reaches. Franco's
+  // known-good SS005-23 file is 240 hourly rows, 2023-06-19 06:00 to
+  // 2023-06-29 06:00 — that last day is a one-row stub with no noon, and it
+  // was rejecting a file that runs correctly.
+
+  const jun19 = at('2023-06-19 13:00:00');
+
+  /** His file's shape: full days, plus a trailing 06:00-only stub. */
+  function ss005Shape(): WeatherDataPoint[] {
+    const days = ['2023-06-19','2023-06-20','2023-06-21','2023-06-22'];
+    const points = days.flatMap((d, i) => hours(d, i === 0 ? 6 : 0, 23));
+    return [...points, ...hours('2023-06-23', 6, 6)];
+  }
+
+  it('accepts a file whose TRAILING day is a stub beyond the run', () => {
+    // 3-day run from Jun 19; the Jun 23 stub is past the end and irrelevant.
+    const result = validateFireStarrContract(ss005Shape(), jun19, ZONE, at('2023-06-22 13:00:00'));
+    expect(result.issues).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  // NOTE: a LEADING partial day is deliberately still rejected. On the CIFFC
+  // demo, four runs whose weather began after noon on the day before the
+  // ignition all died with FATAL: map::at, so that side has crash evidence
+  // behind it and is not relaxed here.
+
+  it('still rejects a missing noon on the IGNITION day', () => {
+    // The day the fire starts must have its noon record.
+    const points = [...hours('2023-06-19', 17, 23), ...hours('2023-06-20', 0, 23)];
+    const result = validateFireStarrContract(points, at('2023-06-19 18:00:00'), ZONE, at('2023-06-20 20:00:00'));
+    expect(result.valid).toBe(false);
+    expect(result.issues.join(' ')).toMatch(/2023-06-19/);
+  });
+
+  it('still rejects a missing noon on a day INSIDE the run', () => {
+    const points = [
+      ...hours('2023-06-19', 0, 23),
+      ...hours('2023-06-20', 13, 23),
+      ...hours('2023-06-21', 0, 23),
+    ];
+    const result = validateFireStarrContract(points, jun19, ZONE, at('2023-06-21 20:00:00'));
+    expect(result.valid).toBe(false);
+    expect(result.issues.join(' ')).toMatch(/2023-06-20/);
+  });
+});
+
 describe('validateFireStarrContract', () => {
   describe('the day-1 noon record (#340)', () => {
     it('accepts a series whose every day carries an hour-12 record', () => {

--- a/backend/src/infrastructure/firestarr/__tests__/weatherContract.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/weatherContract.test.ts
@@ -68,6 +68,19 @@ describe('validateFireStarrContract — the simulated window, not the whole file
   // ignition all died with FATAL: map::at, so that side has crash evidence
   // behind it and is not relaxed here.
 
+  it('says the RUN OUTLASTS THE WEATHER rather than blaming a missing noon', () => {
+    // SS005-23 with the metadata's 241h duration: weather ends 06:00 on the
+    // final day, the run wants to continue to 14:00. Refusing is right; saying
+    // "this day has no noon record" sends the user to trim a file that is fine.
+    const points = [...hours('2023-06-19', 6, 23), ...hours('2023-06-20', 0, 23), ...hours('2023-06-21', 0, 6)];
+    const result = validateFireStarrContract(points, at('2023-06-19 13:00:00'), ZONE, at('2023-06-21 14:00:00'));
+
+    expect(result.valid).toBe(false);
+    const text = result.issues.join(' ');
+    expect(text).toMatch(/weather ends|outlasts|past the weather/i);
+    expect(text).not.toMatch(/starts partway through a day/i);
+  });
+
   it('still rejects a missing noon on the IGNITION day', () => {
     // The day the fire starts must have its noon record.
     const points = [...hours('2023-06-19', 17, 23), ...hours('2023-06-20', 0, 23)];

--- a/backend/src/infrastructure/firestarr/__tests__/weatherContract.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/weatherContract.test.ts
@@ -1,0 +1,150 @@
+/**
+ * FireSTARR weather input contract — issues #339, #340, #341.
+ *
+ * From FireSTARR's own source, quoted in #340:
+ *
+ *   if (12 == t.tm_hour) { auto& s_daily = wx_daily.at(cur); s_daily.emplace(day, ...); }
+ *
+ * Daily values are recorded ONLY on an exact hour-12 record. A day with no such
+ * record never gets an entry, and the later lookup throws `FATAL: map::at` — ten
+ * seconds in, with the reason only in the container log.
+ *
+ * Observed in production on the CIFFC demo 2026-08-19: four of six runs died
+ * this way, every one of them with a weather series whose first day began after
+ * noon (17:00 or 23:00).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DateTime } from 'luxon';
+import { validateFireStarrContract } from '../weatherContract.js';
+import type { WeatherDataPoint } from '../../../application/interfaces/weather.js';
+
+const ZONE = 'America/Edmonton';
+
+function at(stamp: string): Date {
+  return DateTime.fromSQL(stamp, { zone: ZONE }).toJSDate();
+}
+
+/** Hourly points across the given local hours of a day. */
+function hours(day: string, from: number, to: number): WeatherDataPoint[] {
+  const points: WeatherDataPoint[] = [];
+  for (let h = from; h <= to; h++) {
+    points.push({
+      datetime: at(`${day} ${String(h).padStart(2, '0')}:00:00`),
+      temperature: 20, humidity: 45, windSpeed: 10, windDirection: 180,
+      precipitation: 0, ffmc: 85, dmc: 30, dc: 200, isi: 5, bui: 40, fwi: 10,
+    });
+  }
+  return points;
+}
+
+const NOON = at('2026-08-04 12:00:00');
+
+describe('validateFireStarrContract', () => {
+  describe('the day-1 noon record (#340)', () => {
+    it('accepts a series whose every day carries an hour-12 record', () => {
+      const points = [...hours('2026-08-04', 0, 23), ...hours('2026-08-05', 0, 23)];
+      expect(validateFireStarrContract(points, NOON, ZONE).valid).toBe(true);
+    });
+
+    it("rejects Danny's shape — a first day that begins after noon", () => {
+      // The production failures: first day started at 17:00 or 23:00.
+      const points = [...hours('2026-08-04', 17, 23), ...hours('2026-08-05', 0, 23)];
+      const result = validateFireStarrContract(points, at('2026-08-05 12:00:00'), ZONE);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues.join(' ')).toMatch(/2026-08-04/);
+      expect(result.issues.join(' ')).toMatch(/noon|12:00/i);
+    });
+
+    it('rejects a series whose first day starts at 23:00', () => {
+      const points = [...hours('2026-08-04', 23, 23), ...hours('2026-08-05', 0, 23)];
+      expect(validateFireStarrContract(points, at('2026-08-05 12:00:00'), ZONE).valid).toBe(false);
+    });
+
+    it('rejects a MIDDLE day with no noon record — the lookup throws there too', () => {
+      const points = [
+        ...hours('2026-08-04', 0, 23),
+        ...hours('2026-08-05', 13, 23),
+        ...hours('2026-08-06', 0, 23),
+      ];
+      const result = validateFireStarrContract(points, NOON, ZONE);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues.join(' ')).toMatch(/2026-08-05/);
+    });
+
+    it('names every offending day, not just the first', () => {
+      const points = [
+        ...hours('2026-08-04', 13, 23),
+        ...hours('2026-08-05', 13, 23),
+      ];
+      const result = validateFireStarrContract(points, at('2026-08-04 13:00:00'), ZONE);
+
+      expect(result.issues.join(' ')).toMatch(/2026-08-04/);
+      expect(result.issues.join(' ')).toMatch(/2026-08-05/);
+    });
+
+    it('requires hour 12 exactly — 12:30 is not a noon record to FireSTARR', () => {
+      // tm_hour == 12 is the test in the engine, so :30 still satisfies it,
+      // but 13:00 does not. This pins that we match on the HOUR.
+      const half = hours('2026-08-04', 0, 23).map((p) =>
+        DateTime.fromJSDate(p.datetime, { zone: ZONE }).hour === 12
+          ? { ...p, datetime: at('2026-08-04 12:30:00') }
+          : p,
+      );
+      // Ignition at 13:00, after the 12:30 record, so this isolates the HOUR
+      // rule instead of also tripping the ignition-window rule.
+      expect(validateFireStarrContract(half, at('2026-08-04 13:00:00'), ZONE).valid).toBe(true);
+    });
+  });
+
+  describe('the ignition window (#341)', () => {
+    const twoDays = [...hours('2026-08-04', 0, 23), ...hours('2026-08-05', 0, 23)];
+
+    it('accepts an ignition exactly at the day-1 noon record', () => {
+      expect(validateFireStarrContract(twoDays, NOON, ZONE).valid).toBe(true);
+    });
+
+    it('accepts an ignition after noon', () => {
+      expect(validateFireStarrContract(twoDays, at('2026-08-04 15:00:00'), ZONE).valid).toBe(true);
+    });
+
+    it('rejects an ignition BEFORE the day-1 noon record', () => {
+      // 09:00 Monday with the first CFFDRS at noon: the fire starts before any
+      // codes exist for that day, so the codes supplied are never applied.
+      const result = validateFireStarrContract(twoDays, at('2026-08-04 09:00:00'), ZONE);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues.join(' ')).toMatch(/ignition/i);
+    });
+
+    it('rejects an ignition after the weather series ends', () => {
+      const result = validateFireStarrContract(twoDays, at('2026-08-09 12:00:00'), ZONE);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues.join(' ')).toMatch(/ignition/i);
+    });
+
+    it('says what the usable window actually is, so the user can fix it', () => {
+      const result = validateFireStarrContract(twoDays, at('2026-08-04 09:00:00'), ZONE);
+      expect(result.issues.join(' ')).toMatch(/2026-08-04 12:00/);
+    });
+  });
+
+  describe('degenerate input', () => {
+    it('rejects an empty series', () => {
+      const result = validateFireStarrContract([], NOON, ZONE);
+      expect(result.valid).toBe(false);
+      expect(result.issues.length).toBeGreaterThan(0);
+    });
+
+    it('reports every problem at once rather than one per attempt', () => {
+      // A first day with no noon AND an ignition outside the window.
+      const points = hours('2026-08-04', 17, 23);
+      const result = validateFireStarrContract(points, at('2026-08-01 09:00:00'), ZONE);
+
+      expect(result.issues.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/backend/src/infrastructure/firestarr/__tests__/weatherContract.test.ts
+++ b/backend/src/infrastructure/firestarr/__tests__/weatherContract.test.ts
@@ -68,17 +68,17 @@ describe('validateFireStarrContract — the simulated window, not the whole file
   // ignition all died with FATAL: map::at, so that side has crash evidence
   // behind it and is not relaxed here.
 
-  it('says the RUN OUTLASTS THE WEATHER rather than blaming a missing noon', () => {
-    // SS005-23 with the metadata's 241h duration: weather ends 06:00 on the
-    // final day, the run wants to continue to 14:00. Refusing is right; saying
-    // "this day has no noon record" sends the user to trim a file that is fine.
+  it('does NOT reject a run that extends past the end of the weather', () => {
+    // My own addition, removed after it rejected the SS005-23 fire. #341 is
+    // about the IGNITION falling inside the series, not the run end, and the
+    // wizard already guards duration-vs-weather at the Time Range step with a
+    // better message. Duplicating it here in a blunter form only produced
+    // false rejections of a fire that runs correctly.
     const points = [...hours('2023-06-19', 6, 23), ...hours('2023-06-20', 0, 23), ...hours('2023-06-21', 0, 6)];
     const result = validateFireStarrContract(points, at('2023-06-19 13:00:00'), ZONE, at('2023-06-21 14:00:00'));
 
-    expect(result.valid).toBe(false);
-    const text = result.issues.join(' ');
-    expect(text).toMatch(/weather ends|outlasts|past the weather/i);
-    expect(text).not.toMatch(/starts partway through a day/i);
+    expect(result.issues).toEqual([]);
+    expect(result.valid).toBe(true);
   });
 
   it('still rejects a missing noon on the IGNITION day', () => {

--- a/backend/src/infrastructure/firestarr/weatherContract.ts
+++ b/backend/src/infrastructure/firestarr/weatherContract.ts
@@ -67,6 +67,23 @@ export function validateFireStarrContract(
     }
   }
 
+  const lastRecordInstant = points
+    .map((p) => p.datetime)
+    .sort((a, b) => a.getTime() - b.getTime())
+    .at(-1) as Date;
+
+  // A run that continues past the weather is a different fault with a different
+  // remedy, and reporting it as a missing noon sends the user to trim a file
+  // that is fine. Say what is actually wrong.
+  const runOutlastsWeather = runEnd !== undefined && runEnd.getTime() > lastRecordInstant.getTime();
+  if (runOutlastsWeather) {
+    issues.push(
+      `The run continues to ${local(runEnd, timezone).toFormat('yyyy-MM-dd HH:mm')} but the weather ` +
+        `ends at ${local(lastRecordInstant, timezone).toFormat('yyyy-MM-dd HH:mm')}. ` +
+        `Provide weather covering the whole run, or shorten the run to end within it.`,
+    );
+  }
+
   const daysWithoutNoon = [...noonByDay.entries()]
     .filter(([, noon]) => noon === null)
     .map(([day]) => day)
@@ -77,7 +94,10 @@ export function validateFireStarrContract(
       const noonThatDay = DateTime.fromFormat(day, 'yyyy-MM-dd', { zone: timezone }).set({
         hour: NOON_HOUR,
       });
-      return noonThatDay.toMillis() <= runEnd.getTime();
+      // Bounded by the weather as well as the run: past the last observation
+      // the problem is the missing weather, already reported above.
+      const covered = Math.min(runEnd.getTime(), lastRecordInstant.getTime());
+      return noonThatDay.toMillis() <= covered;
     })
     .sort();
 

--- a/backend/src/infrastructure/firestarr/weatherContract.ts
+++ b/backend/src/infrastructure/firestarr/weatherContract.ts
@@ -67,22 +67,15 @@ export function validateFireStarrContract(
     }
   }
 
+  // NOTE: deliberately no "run extends past the weather" rejection here. That
+  // was an addition of mine beyond #341, which concerns the IGNITION sitting
+  // inside the series. The wizard already validates duration against the
+  // weather window at the Time Range step, with a clearer message, and this
+  // blunter copy rejected the SS005-23 fire, which runs correctly.
   const lastRecordInstant = points
     .map((p) => p.datetime)
     .sort((a, b) => a.getTime() - b.getTime())
     .at(-1) as Date;
-
-  // A run that continues past the weather is a different fault with a different
-  // remedy, and reporting it as a missing noon sends the user to trim a file
-  // that is fine. Say what is actually wrong.
-  const runOutlastsWeather = runEnd !== undefined && runEnd.getTime() > lastRecordInstant.getTime();
-  if (runOutlastsWeather) {
-    issues.push(
-      `The run continues to ${local(runEnd, timezone).toFormat('yyyy-MM-dd HH:mm')} but the weather ` +
-        `ends at ${local(lastRecordInstant, timezone).toFormat('yyyy-MM-dd HH:mm')}. ` +
-        `Provide weather covering the whole run, or shorten the run to end within it.`,
-    );
-  }
 
   const daysWithoutNoon = [...noonByDay.entries()]
     .filter(([, noon]) => noon === null)

--- a/backend/src/infrastructure/firestarr/weatherContract.ts
+++ b/backend/src/infrastructure/firestarr/weatherContract.ts
@@ -1,0 +1,124 @@
+/**
+ * FireSTARR's weather input contract — issues #339, #340, #341.
+ *
+ * FireSTARR builds its daily fire weather from noon records only. From its own
+ * source, quoted in #340:
+ *
+ *   if (12 == t.tm_hour) { auto& s_daily = wx_daily.at(cur); s_daily.emplace(day, ...); }
+ *
+ * A day with no hour-12 record therefore never gets a daily entry, and the
+ * later lookup throws `FATAL: map::at` — about ten seconds in, with the reason
+ * visible only in the container log (#339). Four of six runs on the CIFFC demo
+ * died this way on 2026-08-19, every one with a first day that began after noon.
+ *
+ * Checking it here means the user is told what is wrong while they can still
+ * fix it, instead of watching a job fail for reasons they cannot see.
+ */
+
+import { DateTime } from 'luxon';
+import type { WeatherDataPoint } from '../../application/interfaces/weather.js';
+
+export interface ContractResult {
+  valid: boolean;
+  /** Every problem found, phrased for the person who has to fix it. */
+  issues: string[];
+}
+
+/** The hour FireSTARR records its daily values on. Not configurable — it is a literal in the engine. */
+const NOON_HOUR = 12;
+
+function local(instant: Date, timezone: string): DateTime {
+  return DateTime.fromJSDate(instant, { zone: timezone });
+}
+
+/**
+ * @param points   the weather series as it will be written to weather.csv
+ * @param ignition the model start instant — timeRange.start
+ * @param timezone the model's declared IANA zone, which weather.csv is written in
+ */
+export function validateFireStarrContract(
+  points: WeatherDataPoint[],
+  ignition: Date,
+  timezone: string,
+): ContractResult {
+  const issues: string[] = [];
+
+  if (points.length === 0) {
+    return { valid: false, issues: ['The weather series is empty — there is nothing to model.'] };
+  }
+
+  // Group by local day, tracking which days carry an hour-12 record.
+  const noonByDay = new Map<string, Date | null>();
+  for (const point of points) {
+    const zoned = local(point.datetime, timezone);
+    const day = zoned.toFormat('yyyy-MM-dd');
+
+    if (!noonByDay.has(day)) noonByDay.set(day, null);
+    if (zoned.hour === NOON_HOUR && noonByDay.get(day) === null) {
+      noonByDay.set(day, point.datetime);
+    }
+  }
+
+  const daysWithoutNoon = [...noonByDay.entries()]
+    .filter(([, noon]) => noon === null)
+    .map(([day]) => day)
+    .sort();
+
+  if (daysWithoutNoon.length > 0) {
+    issues.push(
+      `FireSTARR builds its daily fire weather from the noon (12:00) record of each day, ` +
+        `and ${daysWithoutNoon.length === 1 ? 'this day has none' : 'these days have none'}: ` +
+        `${daysWithoutNoon.join(', ')}. ` +
+        `Weather that starts partway through a day is the usual cause — trim it to begin at ` +
+        `or before noon, or start the model on the following day.`,
+    );
+  }
+
+  // The ignition must sit at or after the first usable noon record, and within
+  // the series. Before it, the codes for that day do not exist yet and whatever
+  // starting codes were supplied are never applied to the fire.
+  const firstNoon = [...noonByDay.entries()]
+    .filter(([, noon]) => noon !== null)
+    .map(([, noon]) => noon as Date)
+    .sort((a, b) => a.getTime() - b.getTime())[0];
+
+  const lastRecord = points
+    .map((p) => p.datetime)
+    .sort((a, b) => a.getTime() - b.getTime())
+    .at(-1) as Date;
+
+  if (firstNoon && ignition.getTime() < firstNoon.getTime()) {
+    issues.push(
+      `The ignition (${local(ignition, timezone).toFormat('yyyy-MM-dd HH:mm')}) is before the first ` +
+        `noon record in the weather (${local(firstNoon, timezone).toFormat('yyyy-MM-dd HH:mm')}). ` +
+        `FireSTARR has no fire weather for the hours before that, so the starting codes would ` +
+        `never be applied. Set the ignition at or after ${local(firstNoon, timezone).toFormat('yyyy-MM-dd HH:mm')}.`,
+    );
+  }
+
+  if (!firstNoon) {
+    // No noon record anywhere, so there is no "first noon" to measure against.
+    // An ignition before the series still needs reporting on its own terms.
+    const firstRecord = points
+      .map((p) => p.datetime)
+      .sort((a, b) => a.getTime() - b.getTime())[0];
+
+    if (ignition.getTime() < firstRecord.getTime()) {
+      issues.push(
+        `The ignition (${local(ignition, timezone).toFormat('yyyy-MM-dd HH:mm')}) is before the ` +
+          `weather begins (${local(firstRecord, timezone).toFormat('yyyy-MM-dd HH:mm')}). ` +
+          `FireSTARR has no conditions for the fire at all until then.`,
+      );
+    }
+  }
+
+  if (ignition.getTime() > lastRecord.getTime()) {
+    issues.push(
+      `The ignition (${local(ignition, timezone).toFormat('yyyy-MM-dd HH:mm')}) is after the weather ` +
+        `ends (${local(lastRecord, timezone).toFormat('yyyy-MM-dd HH:mm')}). Provide weather that ` +
+        `covers the ignition, or move the ignition into the period the weather covers.`,
+    );
+  }
+
+  return { valid: issues.length === 0, issues };
+}

--- a/backend/src/infrastructure/firestarr/weatherContract.ts
+++ b/backend/src/infrastructure/firestarr/weatherContract.ts
@@ -35,11 +35,19 @@ function local(instant: Date, timezone: string): DateTime {
  * @param points   the weather series as it will be written to weather.csv
  * @param ignition the model start instant — timeRange.start
  * @param timezone the model's declared IANA zone, which weather.csv is written in
+ * @param runEnd   timeRange.end. The contract applies to the SIMULATED WINDOW,
+ *                 not to the whole file: weather files routinely carry trailing
+ *                 hours past the end of the run, and a trailing stub day with no
+ *                 noon record is harmless because the simulation never reaches
+ *                 it. Requiring noon on those days rejected a known-good file
+ *                 (SS005-23: 240 hourly rows ending in a single 06:00 row).
+ *                 Omitted means "check every day", which only tests do.
  */
 export function validateFireStarrContract(
   points: WeatherDataPoint[],
   ignition: Date,
   timezone: string,
+  runEnd?: Date,
 ): ContractResult {
   const issues: string[] = [];
 
@@ -62,6 +70,15 @@ export function validateFireStarrContract(
   const daysWithoutNoon = [...noonByDay.entries()]
     .filter(([, noon]) => noon === null)
     .map(([day]) => day)
+    // Days the run never reaches cannot break it. A leading partial day is NOT
+    // excluded here — that side has production crashes behind it (#340).
+    .filter((day) => {
+      if (!runEnd) return true;
+      const noonThatDay = DateTime.fromFormat(day, 'yyyy-MM-dd', { zone: timezone }).set({
+        hour: NOON_HOUR,
+      });
+      return noonThatDay.toMillis() <= runEnd.getTime();
+    })
     .sort();
 
   if (daysWithoutNoon.length > 0) {

--- a/backend/src/infrastructure/weather/WeatherService.ts
+++ b/backend/src/infrastructure/weather/WeatherService.ts
@@ -20,6 +20,21 @@ import type {
  * "YYYY-MM-DDTHH:mm:ss") against an explicit IANA timezone. The CSV format
  * carries no offset, so the zone MUST be supplied externally.
  */
+/**
+ * Reads a naive weather timestamp as LOCAL time in the model's timezone.
+ *
+ * This is the timezone contract for uploaded weather (#354): the Date column of
+ * a FireSTARR CSV carries local time in the zone the model declares, never UTC.
+ * The upload UI states it, and this is where it is enforced —
+ * DateTime.fromSQL(raw, { zone }) interprets the naive string IN that zone.
+ *
+ * A consequence worth knowing when reasoning about detection: a naive timestamp
+ * parsed in zone Z always reads back as the same wall-clock hour in Z, so the
+ * declared zone cannot shift a row's local hour. A file whose daily CFFDRS rows
+ * do not land at local noon is therefore telling you its timestamps are on a
+ * different clock than declared — see describeDailyRhythm in dailyCffdrs.ts,
+ * which measures exactly that and is surfaced by the pre-flight check.
+ */
 function parseTimestampInZone(raw: string, zone: string): Date {
   const sql = DateTime.fromSQL(raw, { zone });
   if (sql.isValid) return sql.toJSDate();

--- a/backend/src/infrastructure/weather/WeatherService.ts
+++ b/backend/src/infrastructure/weather/WeatherService.ts
@@ -7,6 +7,7 @@
 
 import { ffmc, dmc, dc, isi, bui, fwi } from 'cffdrs';
 import { DateTime, IANAZone } from 'luxon';
+import { localDayKey, localMonth, pickDailyDriverIndices } from './localCalendar.js';
 import type {
   WeatherConfig,
   FWIStartingCodes,
@@ -261,37 +262,48 @@ export class WeatherService {
 
     console.log(`[WeatherService] Processing ${rawRecords.length} raw weather records with cffdrs`);
 
-    // Progressive FWI calculation
-    // FFMC updates every hour (it's an hourly code).
-    // DMC/DC are DAILY codes — they must only update once per calendar day.
-    // Applying daily formulas to every hourly row compounds errors (#234).
-    let prevFFMC = startingCodes.ffmc;
+    // FFMC is an hourly code and steps forward every row.
+    //
+    // DMC and DC are DAILY codes. #234 stopped them recomputing every hour;
+    // #352 puts the once-a-day update on the right day and the right row:
+    // the LOCAL day (UTC midnight is 18:00 the previous local day in Edmonton,
+    // which was splitting single days in two) and the observation nearest
+    // local NOON, which is what CFFDRS defines them against. Driving them from
+    // whichever row came first meant the evening observation — cooler and
+    // damper than the afternoon peak — and biased both codes low for the whole
+    // run.
+    const dayKeys = rawRecords.map((r) => localDayKey(r.datetime, timezone));
+    const drivers = pickDailyDriverIndices(
+      rawRecords.map((r) => r.datetime),
+      timezone,
+    );
+
+    // Walk the days in order, each starting from the previous day's codes.
+    // Day keys are yyyy-MM-dd, so lexical order is chronological order even if
+    // the file itself is not sorted.
+    const dailyCodes = new Map<string, { dmc: number; dc: number }>();
     let prevDMC = startingCodes.dmc;
     let prevDC = startingCodes.dc;
-    let lastDMCUpdateDay = -1; // Track which calendar day we last updated DMC/DC
 
-    return rawRecords.map((record) => {
-      const month = record.datetime.getUTCMonth() + 1;
-      // Day-of-year computed against UTC year-start so the result doesn't shift
-      // by DST or the server's local offset.
-      const dayOfYear = Math.floor(
-        (record.datetime.getTime() - Date.UTC(record.datetime.getUTCFullYear(), 0, 0))
-        / (1000 * 60 * 60 * 24)
-      );
+    for (const day of [...drivers.keys()].sort()) {
+      const driver = rawRecords[drivers.get(day) as number];
+      const month = localMonth(driver.datetime, timezone);
 
+      prevDMC = dmc(prevDMC, driver.temp, driver.rh, driver.prec, latitude, month);
+      prevDC = dc(prevDC, driver.temp, driver.rh, driver.prec, latitude, month);
+      dailyCodes.set(day, { dmc: prevDMC, dc: prevDC });
+    }
+
+    let prevFFMC = startingCodes.ffmc;
+
+    return rawRecords.map((record, index) => {
       // FFMC updates every hour
       const newFFMC = ffmc(prevFFMC, record.temp, record.rh, record.ws, record.prec);
 
-      // DMC/DC update once per calendar day only
-      let newDMC = prevDMC;
-      let newDC = prevDC;
-      if (dayOfYear !== lastDMCUpdateDay) {
-        newDMC = dmc(prevDMC, record.temp, record.rh, record.prec, latitude, month);
-        newDC = dc(prevDC, record.temp, record.rh, record.prec, latitude, month);
-        lastDMCUpdateDay = dayOfYear;
-        prevDMC = newDMC;
-        prevDC = newDC;
-      }
+      // Every hour of a local day carries that day's daily codes.
+      const daily = dailyCodes.get(dayKeys[index]) as { dmc: number; dc: number };
+      const newDMC = daily.dmc;
+      const newDC = daily.dc;
 
       // Calculate derived indices
       const newISI = isi(newFFMC, record.ws);

--- a/backend/src/infrastructure/weather/__tests__/WeatherService.dailyCodes.test.ts
+++ b/backend/src/infrastructure/weather/__tests__/WeatherService.dailyCodes.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Daily DMC/DC rollover — issue #352.
+ *
+ * DMC and DC are daily codes. #234 stopped them recomputing every hour; this
+ * covers the follow-on, that the once-per-day update happens on the right day
+ * and is driven by the right observation.
+ *
+ * Edmonton is UTC-6 in August, so UTC midnight falls at 18:00 local. Under the
+ * old code a single local day was split there and updated twice, and the update
+ * was driven by the evening observation instead of the afternoon one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WeatherService } from '../WeatherService.js';
+
+const ZONE = 'America/Edmonton';
+const HEADER = 'Date,PREC,TEMP,RH,WS,WD';
+
+interface RowSpec {
+  hour: number;
+  temp?: number;
+  rh?: number;
+  prec?: number;
+}
+
+function csv(day: string, rows: RowSpec[]): string {
+  return [
+    HEADER,
+    ...rows.map(
+      ({ hour, temp = 20, rh = 45, prec = 0 }) =>
+        `${day} ${String(hour).padStart(2, '0')}:00:00,${prec},${temp},${rh},10,180`,
+    ),
+  ].join('\n');
+}
+
+function multiDayCsv(days: Array<{ day: string; rows: RowSpec[] }>): string {
+  return [
+    HEADER,
+    ...days.flatMap(({ day, rows }) =>
+      rows.map(
+        ({ hour, temp = 20, rh = 45, prec = 0 }) =>
+          `${day} ${String(hour).padStart(2, '0')}:00:00,${prec},${temp},${rh},10,180`,
+      ),
+    ),
+  ].join('\n');
+}
+
+const service = new WeatherService();
+
+function resolve(content: string) {
+  return service.resolveWeather(
+    {
+      source: 'raw_weather',
+      rawWeatherContent: content,
+      startingCodes: { ffmc: 85, dmc: 25, dc: 300 },
+      latitude: 53.5,
+      timezone: ZONE,
+    },
+    { latitude: 53.5, longitude: -113.5 },
+    { start: new Date('2026-08-04T00:00:00Z'), end: new Date('2026-08-06T00:00:00Z') },
+  );
+}
+
+const ALL_HOURS: RowSpec[] = Array.from({ length: 24 }, (_, hour) => ({ hour }));
+
+describe('daily DMC/DC rollover', () => {
+  it('updates ONCE across a full local day, not twice at the UTC boundary', async () => {
+    // 18:00 and 19:00 local are the next UTC day but the same local day.
+    const points = await resolve(csv('2026-08-04', ALL_HOURS));
+
+    expect(new Set(points.map((p) => p.dmc)).size).toBe(1);
+    expect(new Set(points.map((p) => p.dc)).size).toBe(1);
+  });
+
+  it('updates once per local day across two days', async () => {
+    const points = await resolve(
+      multiDayCsv([
+        { day: '2026-08-04', rows: ALL_HOURS },
+        { day: '2026-08-05', rows: ALL_HOURS },
+      ]),
+    );
+
+    expect(new Set(points.map((p) => p.dmc)).size).toBe(2);
+  });
+
+  it('keeps every hour of a local day on that day’s codes', async () => {
+    const points = await resolve(csv('2026-08-04', ALL_HOURS));
+    const first = points[0];
+
+    for (const point of points) {
+      expect(point.dmc).toBe(first.dmc);
+      expect(point.dc).toBe(first.dc);
+    }
+  });
+});
+
+describe('which observation drives the day', () => {
+  it('is unaffected by evening conditions', async () => {
+    // The old code drove DMC from the 18:00 row, which is cooler and damper
+    // than the afternoon peak and biased the codes low.
+    const mild = await resolve(csv('2026-08-04', ALL_HOURS));
+    const hotEvening = await resolve(
+      csv(
+        '2026-08-04',
+        ALL_HOURS.map((row) => (row.hour === 18 ? { ...row, temp: 38, rh: 12 } : row)),
+      ),
+    );
+
+    expect(hotEvening[0].dmc).toBe(mild[0].dmc);
+    expect(hotEvening[0].dc).toBe(mild[0].dc);
+  });
+
+  it('IS driven by conditions at local noon', async () => {
+    const mild = await resolve(csv('2026-08-04', ALL_HOURS));
+    const hotNoon = await resolve(
+      csv(
+        '2026-08-04',
+        ALL_HOURS.map((row) => (row.hour === 12 ? { ...row, temp: 38, rh: 12 } : row)),
+      ),
+    );
+
+    expect(hotNoon[0].dmc).toBeGreaterThan(mild[0].dmc);
+  });
+
+  it('uses the nearest observation when the day has no noon row', async () => {
+    const rows: RowSpec[] = [{ hour: 8 }, { hour: 11, temp: 38, rh: 12 }, { hour: 16 }];
+    const baseline: RowSpec[] = [{ hour: 8 }, { hour: 11 }, { hour: 16 }];
+
+    const hot = await resolve(csv('2026-08-04', rows));
+    const mild = await resolve(csv('2026-08-04', baseline));
+
+    expect(hot[0].dmc).toBeGreaterThan(mild[0].dmc);
+  });
+});

--- a/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
+++ b/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
@@ -136,8 +136,12 @@ describe('findStartingCodeCandidate', () => {
   });
 
   it('excludes a daily reading exactly at ignition — strictly before', () => {
+    // A single row, so nothing earlier can be returned instead. This isolates
+    // the boundary: the reading is at a daily hour and carries codes, and is
+    // rejected solely for being at ignition rather than before it.
     const atIgnition = new Date('2026-08-03T19:06:00Z');
-    expect(findStartingCodeCandidate(vitasRows(), atIgnition, ZONE)).toBeNull();
+    const rows = [daily('2026-08-03T19:06:00Z', 84.65, 20.72, 424.9)];
+    expect(findStartingCodeCandidate(rows, atIgnition, ZONE)).toBeNull();
   });
 
   it('returns null when no daily reading precedes ignition', () => {

--- a/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
+++ b/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
@@ -272,3 +272,40 @@ describe('describeDailyRhythm', () => {
     expect(describeDailyRhythm([row('2026-08-01 13:00:00')], ZONE)).toBeNull();
   });
 });
+
+describe('invalid timezone (#353)', () => {
+  // Luxon returns an INVALID DateTime for an unrecognised zone rather than
+  // throwing, so local.hour is NaN, no row matches, and the caller receives the
+  // same null it gets for "this file has no usable reading". A configuration
+  // error and a legitimate absence must not look identical.
+
+  it('throws rather than reporting no candidate', () => {
+    expect(() =>
+      findStartingCodeCandidate(vitasRows(), localInstant('2026-08-04 12:00:00'), 'Mars/Olympus_Mons'),
+    ).toThrow(/timezone/i);
+  });
+
+  it('names the offending value', () => {
+    expect(() =>
+      findStartingCodeCandidate(vitasRows(), localInstant('2026-08-04 12:00:00'), 'Not/AZone'),
+    ).toThrow(/Not\/AZone/);
+  });
+
+  it('throws for an empty timezone too', () => {
+    expect(() =>
+      findStartingCodeCandidate(vitasRows(), localInstant('2026-08-04 12:00:00'), ''),
+    ).toThrow(/timezone/i);
+  });
+
+  it('throws from describeDailyRhythm as well', () => {
+    expect(() => describeDailyRhythm(vitasRows(), 'Mars/Olympus_Mons')).toThrow(/timezone/i);
+  });
+
+  it('still accepts every real zone it is given', () => {
+    for (const zone of ['America/Edmonton', 'America/St_Johns', 'UTC', 'Asia/Tokyo']) {
+      expect(() =>
+        findStartingCodeCandidate(vitasRows(), localInstant('2026-08-04 12:00:00'), zone),
+      ).not.toThrow();
+    }
+  });
+});

--- a/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
+++ b/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
@@ -20,6 +20,7 @@ import { DateTime } from 'luxon';
 import {
   hasDailyOnlyCffdrs,
   findStartingCodeCandidate,
+  describeDailyRhythm,
   type CffdrsRow,
 } from '../dailyCffdrs.js';
 
@@ -210,5 +211,64 @@ describe('findStartingCodeCandidate', () => {
     expect(found).not.toBeNull();
     expect(found!.ffmc).toBe(84.65);
     expect(found!.localLabel).toBe('2026-08-04, 1000');
+  });
+});
+
+describe('describeDailyRhythm', () => {
+  // The contract (#354): the CSV Date column is LOCAL time in the model's
+  // timezone. Daily CFFDRS codes are calculated at noon LST, which is local
+  // hour 12, or 13 under daylight time. A file whose daily readings sit
+  // elsewhere is telling us its timestamps are not on the clock we were told.
+
+  it('reports a conforming file as on-contract', () => {
+    const rows = [
+      row('2026-08-01 13:00:00', [81.66, 19.22, 412.67]),
+      row('2026-08-02 03:00:00'),
+      row('2026-08-02 13:00:00', [84.65, 20.72, 424.9]),
+    ];
+    const rhythm = describeDailyRhythm(rows, ZONE);
+
+    expect(rhythm!.dailyHour).toBe(13);
+    expect(rhythm!.likelyZoneMismatch).toBe(false);
+    expect(rhythm!.hoursFromNoon).toBe(0);
+  });
+
+  it('accepts local hour 12 — standard time rather than daylight time', () => {
+    const rows = [row('2026-08-01 12:00:00', [81.66, 19.22, 412.67])];
+    const rhythm = describeDailyRhythm(rows, ZONE);
+
+    expect(rhythm!.likelyZoneMismatch).toBe(false);
+    expect(rhythm!.hoursFromNoon).toBe(0);
+  });
+
+  it("measures vita's file as six hours ahead of contract", () => {
+    // Her daily rows read 19:06. Declared zone is America/Edmonton, MDT, UTC-6.
+    // Six hours ahead of noon is exactly UTC — which is what her file is.
+    const rhythm = describeDailyRhythm(vitasRows(), ZONE);
+
+    expect(rhythm!.dailyHour).toBe(19);
+    expect(rhythm!.likelyZoneMismatch).toBe(true);
+    expect(rhythm!.hoursFromNoon).toBe(6);
+  });
+
+  it('reports a negative offset for a file behind the declared zone', () => {
+    const rows = [row('2026-08-01 09:00:00', [81.66, 19.22, 412.67])];
+    const rhythm = describeDailyRhythm(rows, ZONE);
+
+    expect(rhythm!.hoursFromNoon).toBe(-3);
+    expect(rhythm!.likelyZoneMismatch).toBe(true);
+  });
+
+  it('wraps around midnight rather than measuring the long way', () => {
+    // 01:00 is eleven hours BEFORE noon, not thirteen hours after it.
+    const rows = [row('2026-08-01 01:00:00', [81.66, 19.22, 412.67])];
+    const rhythm = describeDailyRhythm(rows, ZONE);
+
+    expect(rhythm!.hoursFromNoon).toBe(-11);
+    expect(rhythm!.likelyZoneMismatch).toBe(true);
+  });
+
+  it('returns null when no row carries codes — nothing to measure', () => {
+    expect(describeDailyRhythm([row('2026-08-01 13:00:00')], ZONE)).toBeNull();
   });
 });

--- a/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
+++ b/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { DateTime } from 'luxon';
 import {
   hasDailyOnlyCffdrs,
   findStartingCodeCandidate,
@@ -39,17 +40,43 @@ function daily(
   return { datetime: new Date(iso), ffmc, dmc, dc };
 }
 
-/** Vita's file, reduced to the rows that matter. */
+/**
+ * Builds a row the way the parse path really builds one.
+ *
+ * WeatherService reads the CSV Date column with parseTimestampInZone
+ * (WeatherService.ts:23), which is DateTime.fromSQL(raw, { zone }) — the naive
+ * timestamp is interpreted IN the model timezone. So a row written
+ * "2026-08-01 19:06:00" reads back as local hour 19, whatever the zone is.
+ *
+ * The earlier fixture here built genuine UTC instants and so tested a shape the
+ * parser never produces. See #354 for the underlying contract gap.
+ */
+function row(csvTimestamp: string, codes?: [number, number, number]): CffdrsRow {
+  const [ffmc, dmc, dc] = codes ?? [NaN, NaN, NaN];
+  return {
+    datetime: DateTime.fromSQL(csvTimestamp, { zone: ZONE }).toJSDate(),
+    ffmc,
+    dmc,
+    dc,
+  };
+}
+
+/** An instant from a naive local timestamp, as the request's timeRange.start arrives. */
+function localInstant(csvTimestamp: string, zone: string = ZONE): Date {
+  return DateTime.fromSQL(csvTimestamp, { zone }).toJSDate();
+}
+
+/** Vita's file, reduced to the rows that matter — as parsed, not as idealised. */
 function vitasRows(): CffdrsRow[] {
   return [
-    blank('2026-08-01T06:06:00Z'), // 00:06 local
-    daily('2026-08-01T19:06:00Z', 81.66, 19.22, 412.67),
-    blank('2026-08-02T06:06:00Z'),
-    daily('2026-08-02T19:06:00Z', 76.3, 18.52, 418.6),
-    blank('2026-08-03T06:06:00Z'),
-    daily('2026-08-03T19:06:00Z', 84.65, 20.72, 424.9),
-    blank('2026-08-04T06:06:00Z'),
-    daily('2026-08-04T19:06:00Z', 88.44, 23.66, 432.05),
+    row('2026-08-01 00:06:00'),
+    row('2026-08-01 19:06:00', [81.66, 19.22, 412.67]),
+    row('2026-08-02 00:06:00'),
+    row('2026-08-02 19:06:00', [76.3, 18.52, 418.6]),
+    row('2026-08-03 00:06:00'),
+    row('2026-08-03 19:06:00', [84.65, 20.72, 424.9]),
+    row('2026-08-04 00:06:00'),
+    row('2026-08-04 19:06:00', [88.44, 23.66, 432.05]),
   ];
 }
 
@@ -88,7 +115,8 @@ describe('hasDailyOnlyCffdrs', () => {
 });
 
 describe('findStartingCodeCandidate', () => {
-  const ignition = new Date('2026-08-04T18:00:00Z'); // 12:00 local MDT
+  // Her ignition: 2026-08-04 12:00 local.
+  const ignition = localInstant('2026-08-04 12:00:00');
 
   it("returns Aug 3's codes for vita's Aug 4 noon ignition, NOT Aug 4's", () => {
     const found = findStartingCodeCandidate(vitasRows(), ignition, ZONE);
@@ -97,37 +125,49 @@ describe('findStartingCodeCandidate', () => {
     expect(found!.ffmc).toBe(84.65);
     expect(found!.dmc).toBe(20.72);
     expect(found!.dc).toBe(424.9);
-    expect(found!.observedAt.toISOString()).toBe('2026-08-03T19:06:00.000Z');
+    expect(found!.observedAt).toEqual(localInstant('2026-08-03 19:06:00'));
+  });
+
+  it('derives the daily hour from the file rather than assuming noon', () => {
+    // Nothing here sits at hour 12 or 13. The file's own rhythm is hour 19,
+    // and that is what makes these rows the daily readings.
+    const found = findStartingCodeCandidate(vitasRows(), ignition, ZONE);
+    expect(found!.ffmc).toBe(84.65);
+  });
+
+  it('works at any consistent hour — a station that writes its daily at 09:00', () => {
+    const rows = [
+      row('2026-08-01 09:00:00', [81.66, 19.22, 412.67]),
+      row('2026-08-02 03:00:00'),
+      row('2026-08-02 09:00:00', [84.65, 20.72, 424.9]),
+    ];
+    const found = findStartingCodeCandidate(rows, ignition, ZONE);
+    expect(found!.ffmc).toBe(84.65);
+  });
+
+  it('ignores a stray coded row that is off the file rhythm', () => {
+    // Four readings at hour 19 establish the rhythm. One row at 09:06 carries
+    // codes but is not the daily reading, and must not be offered.
+    const rows = [
+      ...vitasRows(),
+      row('2026-08-03 09:06:00', [99.9, 99.9, 99.9]),
+    ];
+    const found = findStartingCodeCandidate(rows, ignition, ZONE);
+    expect(found!.ffmc).toBe(84.65);
   });
 
   it('labels the reading in local time for a human to recognise', () => {
     const found = findStartingCodeCandidate(vitasRows(), ignition, ZONE);
-    expect(found!.localLabel).toBe('2026-08-03, 1300');
+    expect(found!.localLabel).toBe('2026-08-03, 1900');
   });
 
-  it('matches on local hour and ignores minutes entirely', () => {
-    // Stations write at :00, :05, :06, :10 depending on polling. All are the
-    // same daily reading.
+  it('ignores minutes entirely — stations poll at :00, :05, :06, :30', () => {
     for (const minute of ['00', '05', '06', '30', '59']) {
-      const rows = [daily(`2026-08-03T19:${minute}:00Z`, 84.65, 20.72, 424.9)];
+      const rows = [row(`2026-08-03 19:${minute}:00`, [84.65, 20.72, 424.9])];
       const found = findStartingCodeCandidate(rows, ignition, ZONE);
       expect(found, `minute :${minute} should match`).not.toBeNull();
       expect(found!.ffmc).toBe(84.65);
     }
-  });
-
-  it('accepts local hour 12 as well as 13 (standard time vs daylight time)', () => {
-    // 18:06Z = 12:06 MDT
-    const rows = [daily('2026-08-03T18:06:00Z', 84.65, 20.72, 424.9)];
-    const found = findStartingCodeCandidate(rows, ignition, ZONE);
-    expect(found).not.toBeNull();
-    expect(found!.ffmc).toBe(84.65);
-  });
-
-  it('ignores a populated row that is not at a daily hour', () => {
-    // 15:06Z = 09:06 local. Carries codes, but it is not the daily reading.
-    const rows = [daily('2026-08-03T15:06:00Z', 99.9, 99.9, 99.9)];
-    expect(findStartingCodeCandidate(rows, ignition, ZONE)).toBeNull();
   });
 
   it('takes the LAST daily reading before ignition, not the first', () => {
@@ -137,30 +177,38 @@ describe('findStartingCodeCandidate', () => {
 
   it('excludes a daily reading exactly at ignition — strictly before', () => {
     // A single row, so nothing earlier can be returned instead. This isolates
-    // the boundary: the reading is at a daily hour and carries codes, and is
-    // rejected solely for being at ignition rather than before it.
-    const atIgnition = new Date('2026-08-03T19:06:00Z');
-    const rows = [daily('2026-08-03T19:06:00Z', 84.65, 20.72, 424.9)];
-    expect(findStartingCodeCandidate(rows, atIgnition, ZONE)).toBeNull();
+    // the boundary: the row is on rhythm and carries codes, and is rejected
+    // solely for being at ignition rather than before it.
+    const at = localInstant('2026-08-03 19:06:00');
+    const rows = [row('2026-08-03 19:06:00', [84.65, 20.72, 424.9])];
+    expect(findStartingCodeCandidate(rows, at, ZONE)).toBeNull();
   });
 
   it('returns null when no daily reading precedes ignition', () => {
-    const earlyIgnition = new Date('2026-08-01T12:00:00Z');
-    expect(findStartingCodeCandidate(vitasRows(), earlyIgnition, ZONE)).toBeNull();
+    const early = localInstant('2026-08-01 12:00:00');
+    expect(findStartingCodeCandidate(vitasRows(), early, ZONE)).toBeNull();
   });
 
-  it('skips daily-hour rows whose codes are missing', () => {
+  it('returns null when no row carries codes at all', () => {
+    const rows = [row('2026-08-01 19:06:00'), row('2026-08-02 19:06:00')];
+    expect(findStartingCodeCandidate(rows, ignition, ZONE)).toBeNull();
+  });
+
+  it('skips rows on the rhythm whose codes are missing', () => {
     const rows = [
-      daily('2026-08-01T19:06:00Z', 81.66, 19.22, 412.67),
-      blank('2026-08-03T19:06:00Z'), // daily hour, no codes — not usable
+      row('2026-08-01 19:06:00', [81.66, 19.22, 412.67]),
+      row('2026-08-03 19:06:00'), // on rhythm, no codes — not usable
     ];
     const found = findStartingCodeCandidate(rows, ignition, ZONE);
     expect(found!.ffmc).toBe(81.66);
   });
 
-  it('resolves the daily hour in the supplied zone, not the server zone', () => {
-    // The same instants read in Asia/Tokyo are not local noon, so nothing matches.
+  it('labels in the supplied zone — the label moves, the reading does not', () => {
+    // Detection no longer depends on the zone: every row shifts together, so
+    // the rhythm survives. Only the human-facing label is zone-dependent.
     const found = findStartingCodeCandidate(vitasRows(), ignition, 'Asia/Tokyo');
-    expect(found).toBeNull();
+    expect(found).not.toBeNull();
+    expect(found!.ffmc).toBe(84.65);
+    expect(found!.localLabel).toBe('2026-08-04, 1000');
   });
 });

--- a/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
+++ b/backend/src/infrastructure/weather/__tests__/dailyCffdrs.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Daily-only CFFDRS detection and starting-code recovery — issue #351.
+ *
+ * Built from vita's real file. Hourly station observations from a station that
+ * writes at :06, with the CFFDRS indices recorded once per day at 19:06 UTC —
+ * 13:06 MDT, which is noon LST. Six upload attempts over a week, all segfaults.
+ *
+ * The eleven daily readings in her file begin:
+ *   2026-08-01 19:06   FFMC 81.66  DMC 19.22  DC 412.67
+ *   2026-08-02 19:06   FFMC 76.30  DMC 18.52  DC 418.60
+ *   2026-08-03 19:06   FFMC 84.65  DMC 20.72  DC 424.90
+ *   2026-08-04 19:06   FFMC 88.44  DMC 23.66  DC 432.05
+ *
+ * Her ignition is 2026-08-04 12:00 local. The 08-04 daily row is hour 13 —
+ * an hour too late. The correct answer is 08-03's codes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  hasDailyOnlyCffdrs,
+  findStartingCodeCandidate,
+  type CffdrsRow,
+} from '../dailyCffdrs.js';
+
+const ZONE = 'America/Edmonton'; // MDT in August = UTC-6
+
+/** A row with no codes — every non-noon row in her file. */
+function blank(iso: string): CffdrsRow {
+  return { datetime: new Date(iso), ffmc: NaN, dmc: NaN, dc: NaN };
+}
+
+/** A row carrying a daily reading. */
+function daily(
+  iso: string,
+  ffmc: number,
+  dmc: number,
+  dc: number,
+): CffdrsRow {
+  return { datetime: new Date(iso), ffmc, dmc, dc };
+}
+
+/** Vita's file, reduced to the rows that matter. */
+function vitasRows(): CffdrsRow[] {
+  return [
+    blank('2026-08-01T06:06:00Z'), // 00:06 local
+    daily('2026-08-01T19:06:00Z', 81.66, 19.22, 412.67),
+    blank('2026-08-02T06:06:00Z'),
+    daily('2026-08-02T19:06:00Z', 76.3, 18.52, 418.6),
+    blank('2026-08-03T06:06:00Z'),
+    daily('2026-08-03T19:06:00Z', 84.65, 20.72, 424.9),
+    blank('2026-08-04T06:06:00Z'),
+    daily('2026-08-04T19:06:00Z', 88.44, 23.66, 432.05),
+  ];
+}
+
+describe('hasDailyOnlyCffdrs', () => {
+  it("detects the shape in vita's file", () => {
+    expect(hasDailyOnlyCffdrs(vitasRows())).toBe(true);
+  });
+
+  it('is false when every row carries codes (a conforming firestarr_csv)', () => {
+    const rows = [
+      daily('2026-08-01T06:06:00Z', 81.66, 19.22, 412.67),
+      daily('2026-08-01T07:06:00Z', 81.7, 19.3, 412.8),
+    ];
+    expect(hasDailyOnlyCffdrs(rows)).toBe(false);
+  });
+
+  it('is false when NO row carries codes — nothing to recover', () => {
+    // A different failure. There are no codes to offer, so this must not be
+    // reported as the recoverable daily-only shape.
+    const rows = [blank('2026-08-01T06:06:00Z'), blank('2026-08-01T07:06:00Z')];
+    expect(hasDailyOnlyCffdrs(rows)).toBe(false);
+  });
+
+  it('is false for an empty file', () => {
+    expect(hasDailyOnlyCffdrs([])).toBe(false);
+  });
+
+  it('treats a partially-populated row as missing codes', () => {
+    // FFMC present but DMC/DC absent is not a usable daily reading.
+    const rows = [
+      { datetime: new Date('2026-08-01T19:06:00Z'), ffmc: 84.65, dmc: NaN, dc: NaN },
+      blank('2026-08-01T20:06:00Z'),
+    ];
+    expect(hasDailyOnlyCffdrs(rows)).toBe(false);
+  });
+});
+
+describe('findStartingCodeCandidate', () => {
+  const ignition = new Date('2026-08-04T18:00:00Z'); // 12:00 local MDT
+
+  it("returns Aug 3's codes for vita's Aug 4 noon ignition, NOT Aug 4's", () => {
+    const found = findStartingCodeCandidate(vitasRows(), ignition, ZONE);
+
+    expect(found).not.toBeNull();
+    expect(found!.ffmc).toBe(84.65);
+    expect(found!.dmc).toBe(20.72);
+    expect(found!.dc).toBe(424.9);
+    expect(found!.observedAt.toISOString()).toBe('2026-08-03T19:06:00.000Z');
+  });
+
+  it('labels the reading in local time for a human to recognise', () => {
+    const found = findStartingCodeCandidate(vitasRows(), ignition, ZONE);
+    expect(found!.localLabel).toBe('2026-08-03, 1300');
+  });
+
+  it('matches on local hour and ignores minutes entirely', () => {
+    // Stations write at :00, :05, :06, :10 depending on polling. All are the
+    // same daily reading.
+    for (const minute of ['00', '05', '06', '30', '59']) {
+      const rows = [daily(`2026-08-03T19:${minute}:00Z`, 84.65, 20.72, 424.9)];
+      const found = findStartingCodeCandidate(rows, ignition, ZONE);
+      expect(found, `minute :${minute} should match`).not.toBeNull();
+      expect(found!.ffmc).toBe(84.65);
+    }
+  });
+
+  it('accepts local hour 12 as well as 13 (standard time vs daylight time)', () => {
+    // 18:06Z = 12:06 MDT
+    const rows = [daily('2026-08-03T18:06:00Z', 84.65, 20.72, 424.9)];
+    const found = findStartingCodeCandidate(rows, ignition, ZONE);
+    expect(found).not.toBeNull();
+    expect(found!.ffmc).toBe(84.65);
+  });
+
+  it('ignores a populated row that is not at a daily hour', () => {
+    // 15:06Z = 09:06 local. Carries codes, but it is not the daily reading.
+    const rows = [daily('2026-08-03T15:06:00Z', 99.9, 99.9, 99.9)];
+    expect(findStartingCodeCandidate(rows, ignition, ZONE)).toBeNull();
+  });
+
+  it('takes the LAST daily reading before ignition, not the first', () => {
+    const found = findStartingCodeCandidate(vitasRows(), ignition, ZONE);
+    expect(found!.ffmc).toBe(84.65); // Aug 3, not Aug 1's 81.66
+  });
+
+  it('excludes a daily reading exactly at ignition — strictly before', () => {
+    const atIgnition = new Date('2026-08-03T19:06:00Z');
+    expect(findStartingCodeCandidate(vitasRows(), atIgnition, ZONE)).toBeNull();
+  });
+
+  it('returns null when no daily reading precedes ignition', () => {
+    const earlyIgnition = new Date('2026-08-01T12:00:00Z');
+    expect(findStartingCodeCandidate(vitasRows(), earlyIgnition, ZONE)).toBeNull();
+  });
+
+  it('skips daily-hour rows whose codes are missing', () => {
+    const rows = [
+      daily('2026-08-01T19:06:00Z', 81.66, 19.22, 412.67),
+      blank('2026-08-03T19:06:00Z'), // daily hour, no codes — not usable
+    ];
+    const found = findStartingCodeCandidate(rows, ignition, ZONE);
+    expect(found!.ffmc).toBe(81.66);
+  });
+
+  it('resolves the daily hour in the supplied zone, not the server zone', () => {
+    // The same instants read in Asia/Tokyo are not local noon, so nothing matches.
+    const found = findStartingCodeCandidate(vitasRows(), ignition, 'Asia/Tokyo');
+    expect(found).toBeNull();
+  });
+});

--- a/backend/src/infrastructure/weather/__tests__/dailyOnlyRecovery.e2e.test.ts
+++ b/backend/src/infrastructure/weather/__tests__/dailyOnlyRecovery.e2e.test.ts
@@ -1,0 +1,166 @@
+/**
+ * End-to-end recovery of a daily-only CFFDRS file — issues #350, #351.
+ *
+ * The failure this reproduces: a FireSTARR-format CSV recording its indices
+ * once a day parsed to NaN on every other row, those NaNs were written to
+ * weather.csv AND placed on the FireSTARR command line, and the engine died
+ * with SIGSEGV. vita hit it six times in a week on the CIFFC demo.
+ *
+ * The fixture reproduces the SHAPE of her file — hourly observations at :06
+ * with the indices on the 19:06 row only. The first four daily readings are the
+ * exact values recorded in #351; the rest continue the trend and are invented.
+ *
+ * This covers the whole recovery: detect the shape, recover the codes, run them
+ * through the raw_weather path, and confirm nothing non-finite survives.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WeatherService } from '../WeatherService.js';
+import { hasDailyOnlyCffdrs, findStartingCodeCandidate } from '../dailyCffdrs.js';
+import { validateWeatherData } from '../../firestarr/WeatherCSVWriter.js';
+
+const ZONE = 'America/Edmonton';
+const IGNITION = new Date('2026-08-04T18:00:00.000Z'); // 12:00 local
+
+const DAILY_READINGS: Record<string, [number, number, number]> = {
+  '2026-08-01': [81.66, 19.22, 412.67],
+  '2026-08-02': [76.3, 18.52, 418.6],
+  '2026-08-03': [84.65, 20.72, 424.9],
+  '2026-08-04': [88.44, 23.66, 432.05],
+};
+
+const TEMPS = [16.1, 15.4, 14.9, 14.5, 14.2, 15.0, 17.3, 19.8, 21.9, 23.4, 24.4, 25.1,
+  25.8, 26.3, 26.6, 26.4, 25.7, 24.8, 23.8, 22.1, 20.4, 19.0, 17.9, 16.9];
+const RHS = [72, 75, 78, 80, 82, 79, 70, 60, 52, 48, 46, 43, 41, 39, 38, 39, 43, 50, 61, 66, 69, 71, 72, 73];
+
+function vitaShapedCsv(): string {
+  const lines = ['Scenario,Date,PREC,TEMP,RH,WS,WD,FFMC,DMC,DC,ISI,BUI,FWI'];
+
+  for (const [day, [ffmc, dmc, dc]] of Object.entries(DAILY_READINGS)) {
+    for (let hour = 0; hour < 24; hour++) {
+      const stamp = `${day} ${String(hour).padStart(2, '0')}:06:00`;
+      const observation = `0,${stamp},0,${TEMPS[hour]},${RHS[hour]},8.0,222`;
+
+      lines.push(
+        hour === 19
+          ? `${observation.replace(',222', ',217')},${ffmc},${dmc},${dc},2,34.44,4.64`
+          : `${observation},NaN,NaN,NaN,NaN,NaN,NaN`,
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+const service = new WeatherService();
+
+describe("vita's file, end to end", () => {
+  it('parses to NaN when taken at face value — the original failure', async () => {
+    const points = await service.resolveWeather(
+      { source: 'firestarr_csv', firestarrCsvContent: vitaShapedCsv(), timezone: ZONE },
+      { latitude: 53.5, longitude: -113.5 },
+      { start: IGNITION, end: IGNITION },
+    );
+
+    // 92 of 96 rows carry no indices at all.
+    expect(points.some((p) => !Number.isFinite(p.ffmc))).toBe(true);
+  });
+
+  it('is now REJECTED by validation instead of reaching the engine (#350)', async () => {
+    const points = await service.resolveWeather(
+      { source: 'firestarr_csv', firestarrCsvContent: vitaShapedCsv(), timezone: ZONE },
+      { latitude: 53.5, longitude: -113.5 },
+      { start: IGNITION, end: IGNITION },
+    );
+
+    const result = validateWeatherData(
+      points.map((p) => ({
+        date: p.datetime,
+        temp: p.temperature,
+        rh: p.humidity,
+        ws: p.windSpeed,
+        wd: p.windDirection,
+        precip: p.precipitation,
+        ffmc: p.ffmc,
+        dmc: p.dmc,
+        dc: p.dc,
+        isi: p.isi ?? 0,
+        bui: p.bui ?? 0,
+        fwi: p.fwi ?? 0,
+      })) as Parameters<typeof validateWeatherData>[0],
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('recovers the codes the file already contains (#351)', async () => {
+    const points = await service.resolveWeather(
+      { source: 'firestarr_csv', firestarrCsvContent: vitaShapedCsv(), timezone: ZONE },
+      { latitude: 53.5, longitude: -113.5 },
+      { start: IGNITION, end: IGNITION },
+    );
+
+    expect(hasDailyOnlyCffdrs(points)).toBe(true);
+
+    const candidate = findStartingCodeCandidate(points, IGNITION, ZONE);
+    expect(candidate).not.toBeNull();
+    expect([candidate!.ffmc, candidate!.dmc, candidate!.dc]).toEqual([84.65, 20.72, 424.9]);
+  });
+
+  it('produces a fully finite series once those codes are accepted', async () => {
+    // The payoff. Same file, raw_weather path, codes recovered from the file
+    // itself — every row now carries real numbers.
+    const points = await service.resolveWeather(
+      {
+        source: 'raw_weather',
+        rawWeatherContent: vitaShapedCsv(),
+        startingCodes: { ffmc: 84.65, dmc: 20.72, dc: 424.9 },
+        latitude: 53.5,
+        timezone: ZONE,
+      },
+      { latitude: 53.5, longitude: -113.5 },
+      { start: IGNITION, end: IGNITION },
+    );
+
+    expect(points.length).toBe(96);
+    for (const point of points) {
+      expect(Number.isFinite(point.ffmc)).toBe(true);
+      expect(Number.isFinite(point.dmc)).toBe(true);
+      expect(Number.isFinite(point.dc)).toBe(true);
+    }
+  });
+
+  it('passes the validation that used to let NaN through to the command line', async () => {
+    const points = await service.resolveWeather(
+      {
+        source: 'raw_weather',
+        rawWeatherContent: vitaShapedCsv(),
+        startingCodes: { ffmc: 84.65, dmc: 20.72, dc: 424.9 },
+        latitude: 53.5,
+        timezone: ZONE,
+      },
+      { latitude: 53.5, longitude: -113.5 },
+      { start: IGNITION, end: IGNITION },
+    );
+
+    const result = validateWeatherData(
+      points.map((p) => ({
+        date: p.datetime,
+        temp: p.temperature,
+        rh: p.humidity,
+        ws: p.windSpeed,
+        wd: p.windDirection,
+        precip: p.precipitation,
+        ffmc: p.ffmc,
+        dmc: p.dmc,
+        dc: p.dc,
+        isi: p.isi ?? 0,
+        bui: p.bui ?? 0,
+        fwi: p.fwi ?? 0,
+      })) as Parameters<typeof validateWeatherData>[0],
+    );
+
+    expect(result.issues).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/backend/src/infrastructure/weather/__tests__/localCalendar.test.ts
+++ b/backend/src/infrastructure/weather/__tests__/localCalendar.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Local calendar helpers — issue #352.
+ *
+ * DMC and DC are DAILY codes. They must update once per LOCAL day, driven by
+ * the observation nearest local noon, because CFFDRS defines them against noon
+ * LST conditions. The previous code rolled them over on the UTC day boundary,
+ * which in Edmonton is 18:00 the previous local day.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DateTime } from 'luxon';
+import { localDayKey, localMonth, pickDailyDriverIndices } from '../localCalendar.js';
+
+const ZONE = 'America/Edmonton';
+
+/** A row as the parser produces one: naive local timestamp read in the zone. */
+function at(csvTimestamp: string, zone: string = ZONE): Date {
+  return DateTime.fromSQL(csvTimestamp, { zone }).toJSDate();
+}
+
+describe('localDayKey', () => {
+  it('keeps a whole local day on one key, across the UTC midnight boundary', () => {
+    // 18:00 local is when UTC rolls over in MDT. Both belong to Aug 4 locally.
+    expect(localDayKey(at('2026-08-04 17:00:00'), ZONE)).toBe('2026-08-04');
+    expect(localDayKey(at('2026-08-04 19:00:00'), ZONE)).toBe('2026-08-04');
+  });
+
+  it('separates adjacent local days', () => {
+    expect(localDayKey(at('2026-08-04 23:00:00'), ZONE)).toBe('2026-08-04');
+    expect(localDayKey(at('2026-08-05 00:00:00'), ZONE)).toBe('2026-08-05');
+  });
+
+  it('reads the day in the supplied zone, not the server zone', () => {
+    const instant = at('2026-08-04 23:00:00', 'UTC');
+    expect(localDayKey(instant, 'UTC')).toBe('2026-08-04');
+    expect(localDayKey(instant, ZONE)).toBe('2026-08-04');
+    expect(localDayKey(instant, 'Asia/Tokyo')).toBe('2026-08-05');
+  });
+});
+
+describe('localMonth', () => {
+  it('is 1-based', () => {
+    expect(localMonth(at('2026-08-04 12:00:00'), ZONE)).toBe(8);
+  });
+
+  it('does not spill into the next month on the last local evening', () => {
+    // 20:00 local on Jul 31 is Aug 1 in UTC. The day-length factor must still
+    // be July's.
+    expect(localMonth(at('2026-07-31 20:00:00'), ZONE)).toBe(7);
+  });
+
+  it('does not fall back into the previous month on the first local morning', () => {
+    expect(localMonth(at('2026-08-01 01:00:00'), ZONE)).toBe(8);
+  });
+});
+
+describe('pickDailyDriverIndices', () => {
+  function hourly(day: string, hours: number[]): Date[] {
+    return hours.map((h) => at(`${day} ${String(h).padStart(2, '0')}:00:00`));
+  }
+
+  it('picks the noon observation to drive the day', () => {
+    const rows = hourly('2026-08-04', [0, 6, 12, 18, 23]);
+    const picked = pickDailyDriverIndices(rows, ZONE);
+
+    expect(picked.size).toBe(1);
+    expect(picked.get('2026-08-04')).toBe(2); // the 12:00 row
+  });
+
+  it('picks the observation NEAREST noon when there is no noon row', () => {
+    // Stations poll at :06, or start mid-morning. Nearest is well defined.
+    const rows = hourly('2026-08-04', [7, 11, 15]);
+    const picked = pickDailyDriverIndices(rows, ZONE);
+
+    expect(picked.get('2026-08-04')).toBe(1); // 11:00, one hour from noon
+  });
+
+  it('gives each local day its own driver', () => {
+    const rows = [...hourly('2026-08-04', [0, 12, 23]), ...hourly('2026-08-05', [0, 12])];
+    const picked = pickDailyDriverIndices(rows, ZONE);
+
+    expect(picked.size).toBe(2);
+    expect(picked.get('2026-08-04')).toBe(1);
+    expect(picked.get('2026-08-05')).toBe(4);
+  });
+
+  it('does NOT split one local day at the UTC boundary', () => {
+    // The whole bug: 18:00 and 19:00 local are the next UTC day, but the same
+    // local day, and must not trigger a second daily update.
+    const rows = hourly('2026-08-04', [12, 17, 18, 19, 23]);
+    const picked = pickDailyDriverIndices(rows, ZONE);
+
+    expect(picked.size).toBe(1);
+  });
+
+  it('prefers the earlier observation when two are equally near noon', () => {
+    const rows = hourly('2026-08-04', [11, 13]);
+    const picked = pickDailyDriverIndices(rows, ZONE);
+
+    expect(picked.get('2026-08-04')).toBe(0);
+  });
+
+  it('handles an empty file', () => {
+    expect(pickDailyDriverIndices([], ZONE).size).toBe(0);
+  });
+});

--- a/backend/src/infrastructure/weather/dailyCffdrs.ts
+++ b/backend/src/infrastructure/weather/dailyCffdrs.ts
@@ -17,7 +17,7 @@
  * Pure functions only. No HTTP, no filesystem, no engine.
  */
 
-import { DateTime } from 'luxon';
+import { DateTime, IANAZone } from 'luxon';
 
 /**
  * The minimal shape this module needs. Declared here rather than imported so
@@ -40,6 +40,21 @@ export interface StartingCodeCandidate {
   observedAt: Date;
   /** Human-facing local label, e.g. "2026-08-03, 1300". */
   localLabel: string;
+}
+
+/**
+ * Rejects a zone Luxon cannot resolve — issue #353.
+ *
+ * Luxon returns an INVALID DateTime for an unrecognised zone rather than
+ * throwing. Its .hour is then NaN, no row matches, and the caller receives the
+ * same null that means "this file has no usable reading". A configuration error
+ * and a legitimate absence must not be indistinguishable: the first is a bug to
+ * fix, the second is an answer.
+ */
+function assertZone(timezone: string): void {
+  if (!timezone || !IANAZone.isValidZone(timezone)) {
+    throw new Error(`Invalid IANA timezone: ${timezone === '' ? '(empty)' : timezone}`);
+  }
 }
 
 /** True when all three codes on a row are usable numbers. */
@@ -117,6 +132,8 @@ export function findStartingCodeCandidate(
   ignition: Date,
   timezone: string,
 ): StartingCodeCandidate | null {
+  assertZone(timezone);
+
   const dailyHour = deriveDailyHour(rows, timezone);
   if (dailyHour === null) return null;
 
@@ -192,6 +209,8 @@ export function describeDailyRhythm(
   rows: CffdrsRow[],
   timezone: string,
 ): DailyRhythm | null {
+  assertZone(timezone);
+
   const dailyHour = deriveDailyHour(rows, timezone);
   if (dailyHour === null) return null;
 

--- a/backend/src/infrastructure/weather/dailyCffdrs.ts
+++ b/backend/src/infrastructure/weather/dailyCffdrs.ts
@@ -64,8 +64,14 @@ function hasCodes(row: CffdrsRow): boolean {
  * Returns false when every row has codes (a conforming firestarr_csv) and false
  * when no row has codes (nothing to recover — a different failure).
  */
-export function hasDailyOnlyCffdrs(_rows: CffdrsRow[]): boolean {
-  throw new Error('not implemented');
+export function hasDailyOnlyCffdrs(rows: CffdrsRow[]): boolean {
+  if (rows.length === 0) return false;
+
+  const withCodes = rows.filter(hasCodes).length;
+
+  // Both sides must be non-empty. All-codes is a conforming firestarr_csv;
+  // no-codes is a different failure with nothing to recover.
+  return withCodes > 0 && withCodes < rows.length;
 }
 
 /**
@@ -79,14 +85,34 @@ export function hasDailyOnlyCffdrs(_rows: CffdrsRow[]): boolean {
  * Returns null when no such reading exists — the caller must not invent one.
  */
 export function findStartingCodeCandidate(
-  _rows: CffdrsRow[],
-  _ignition: Date,
-  _timezone: string,
+  rows: CffdrsRow[],
+  ignition: Date,
+  timezone: string,
 ): StartingCodeCandidate | null {
-  throw new Error('not implemented');
-}
+  let best: CffdrsRow | null = null;
 
-// Referenced by the implementation; declared above to keep the contract visible.
-void DAILY_READING_LOCAL_HOURS;
-void hasCodes;
-void DateTime;
+  for (const row of rows) {
+    if (!hasCodes(row)) continue;
+    if (row.datetime.getTime() >= ignition.getTime()) continue;
+
+    const local = DateTime.fromJSDate(row.datetime, { zone: timezone });
+    if (!DAILY_READING_LOCAL_HOURS.includes(local.hour)) continue;
+
+    if (best === null || row.datetime.getTime() > best.datetime.getTime()) {
+      best = row;
+    }
+  }
+
+  if (best === null) return null;
+
+  const local = DateTime.fromJSDate(best.datetime, { zone: timezone });
+
+  return {
+    ffmc: best.ffmc,
+    dmc: best.dmc,
+    dc: best.dc,
+    observedAt: best.datetime,
+    // Minutes are deliberately dropped — the reading names an hour, not an instant.
+    localLabel: `${local.toFormat('yyyy-MM-dd, HH')}00`,
+  };
+}

--- a/backend/src/infrastructure/weather/dailyCffdrs.ts
+++ b/backend/src/infrastructure/weather/dailyCffdrs.ts
@@ -42,15 +42,6 @@ export interface StartingCodeCandidate {
   localLabel: string;
 }
 
-/**
- * Local hours that count as the daily CFFDRS reading.
- *
- * Daily codes are calculated at noon local standard time. Under daylight time
- * that lands on local hour 13, so both are accepted. Minutes are ignored
- * entirely — stations write at :00, :05, :06 or :10 depending on polling.
- */
-const DAILY_READING_LOCAL_HOURS = [12, 13];
-
 /** True when all three codes on a row are usable numbers. */
 function hasCodes(row: CffdrsRow): boolean {
   return (
@@ -75,6 +66,43 @@ export function hasDailyOnlyCffdrs(rows: CffdrsRow[]): boolean {
 }
 
 /**
+ * Derives the hour-of-day at which this file records its daily reading.
+ *
+ * Daily codes are calculated at noon LST, but we cannot look for local noon:
+ * the CSV Date column is parsed with parseTimestampInZone (WeatherService.ts:23),
+ * which interprets the naive timestamp IN the model timezone. A row written
+ * "19:06" therefore reads back as local hour 19 no matter which zone is
+ * declared, so a hardcoded noon never matches. See #354.
+ *
+ * The file already tells us. The hour that repeatedly carries codes IS the
+ * daily reading, under either reading of the Date column. Ties resolve to the
+ * first hour seen, which keeps the result deterministic.
+ *
+ * Returns null when no row carries codes.
+ */
+function deriveDailyHour(rows: CffdrsRow[], timezone: string): number | null {
+  const countByHour = new Map<number, number>();
+
+  for (const row of rows) {
+    if (!hasCodes(row)) continue;
+    const { hour } = DateTime.fromJSDate(row.datetime, { zone: timezone });
+    if (!Number.isFinite(hour)) continue;
+    countByHour.set(hour, (countByHour.get(hour) ?? 0) + 1);
+  }
+
+  let dailyHour: number | null = null;
+  let best = 0;
+  for (const [hour, count] of countByHour) {
+    if (count > best) {
+      best = count;
+      dailyHour = hour;
+    }
+  }
+
+  return dailyHour;
+}
+
+/**
  * Finds the daily reading to offer as starting codes: the last row at a daily
  * local hour that falls STRICTLY BEFORE ignition.
  *
@@ -89,14 +117,17 @@ export function findStartingCodeCandidate(
   ignition: Date,
   timezone: string,
 ): StartingCodeCandidate | null {
+  const dailyHour = deriveDailyHour(rows, timezone);
+  if (dailyHour === null) return null;
+
   let best: CffdrsRow | null = null;
 
   for (const row of rows) {
     if (!hasCodes(row)) continue;
     if (row.datetime.getTime() >= ignition.getTime()) continue;
 
-    const local = DateTime.fromJSDate(row.datetime, { zone: timezone });
-    if (!DAILY_READING_LOCAL_HOURS.includes(local.hour)) continue;
+    const { hour } = DateTime.fromJSDate(row.datetime, { zone: timezone });
+    if (hour !== dailyHour) continue;
 
     if (best === null || row.datetime.getTime() > best.datetime.getTime()) {
       best = row;

--- a/backend/src/infrastructure/weather/dailyCffdrs.ts
+++ b/backend/src/infrastructure/weather/dailyCffdrs.ts
@@ -1,0 +1,92 @@
+/**
+ * Daily-only CFFDRS detection and starting-code recovery.
+ *
+ * Issue #351. Nomad supports two weather contracts and only two:
+ *
+ *   firestarr_csv — CFFDRS values on EVERY row, passed straight through
+ *   raw_weather   — raw observations PLUS starting codes, Nomad calculates the rest
+ *
+ * A standard fire weather station writes hourly observations with the CFFDRS
+ * indices recorded once per day, at noon LST. That file satisfies neither
+ * contract: it enters as firestarr_csv, every non-noon row parses to NaN, and
+ * the NaN reaches the FireSTARR command line and segfaults the engine.
+ *
+ * The user already has the starting codes — they are in the file. This module
+ * finds them so they can be offered rather than guessed at or refused.
+ *
+ * Pure functions only. No HTTP, no filesystem, no engine.
+ */
+
+import { DateTime } from 'luxon';
+
+/**
+ * The minimal shape this module needs. Declared here rather than imported so
+ * the detection logic does not depend on WeatherService's internals — any
+ * record carrying a timestamp and three codes satisfies it structurally.
+ */
+export interface CffdrsRow {
+  datetime: Date;
+  ffmc: number;
+  dmc: number;
+  dc: number;
+}
+
+/** A daily reading recovered from the file, ready to be offered to the user. */
+export interface StartingCodeCandidate {
+  ffmc: number;
+  dmc: number;
+  dc: number;
+  /** The instant the reading was taken. */
+  observedAt: Date;
+  /** Human-facing local label, e.g. "2026-08-03, 1300". */
+  localLabel: string;
+}
+
+/**
+ * Local hours that count as the daily CFFDRS reading.
+ *
+ * Daily codes are calculated at noon local standard time. Under daylight time
+ * that lands on local hour 13, so both are accepted. Minutes are ignored
+ * entirely — stations write at :00, :05, :06 or :10 depending on polling.
+ */
+const DAILY_READING_LOCAL_HOURS = [12, 13];
+
+/** True when all three codes on a row are usable numbers. */
+function hasCodes(row: CffdrsRow): boolean {
+  return (
+    Number.isFinite(row.ffmc) && Number.isFinite(row.dmc) && Number.isFinite(row.dc)
+  );
+}
+
+/**
+ * Detects the daily-only CFFDRS shape: some rows carry codes, others do not.
+ *
+ * Returns false when every row has codes (a conforming firestarr_csv) and false
+ * when no row has codes (nothing to recover — a different failure).
+ */
+export function hasDailyOnlyCffdrs(_rows: CffdrsRow[]): boolean {
+  throw new Error('not implemented');
+}
+
+/**
+ * Finds the daily reading to offer as starting codes: the last row at a daily
+ * local hour that falls STRICTLY BEFORE ignition.
+ *
+ * Strictly before matters. For an ignition at noon local, the same day's daily
+ * row is typically an hour too late, and using it would be wrong for every
+ * morning fire.
+ *
+ * Returns null when no such reading exists — the caller must not invent one.
+ */
+export function findStartingCodeCandidate(
+  _rows: CffdrsRow[],
+  _ignition: Date,
+  _timezone: string,
+): StartingCodeCandidate | null {
+  throw new Error('not implemented');
+}
+
+// Referenced by the implementation; declared above to keep the contract visible.
+void DAILY_READING_LOCAL_HOURS;
+void hasCodes;
+void DateTime;

--- a/backend/src/infrastructure/weather/dailyCffdrs.ts
+++ b/backend/src/infrastructure/weather/dailyCffdrs.ts
@@ -147,3 +147,65 @@ export function findStartingCodeCandidate(
     localLabel: `${local.toFormat('yyyy-MM-dd, HH')}00`,
   };
 }
+
+/**
+ * The hours at which a conforming file records its daily reading.
+ *
+ * The contract (#354) is that the CSV Date column carries LOCAL time in the
+ * model's timezone. Daily CFFDRS codes are calculated at noon LST — local hour
+ * 12, or 13 where daylight time is in force.
+ */
+const CONTRACT_DAILY_HOURS = [12, 13];
+
+/** What a file's own rhythm says about whether its timestamps match the declared zone. */
+export interface DailyRhythm {
+  /** The local hour that repeatedly carries codes. */
+  dailyHour: number;
+  /**
+   * Signed hours between that hour and noon, wrapped to the shorter way round
+   * the clock. Zero means on-contract. Six means the timestamps run six hours
+   * ahead of the zone the model declares.
+   */
+  hoursFromNoon: number;
+  /** True when the file's rhythm does not sit at noon — the declared zone is suspect. */
+  likelyZoneMismatch: boolean;
+}
+
+/** Wraps an hour difference into [-12, 12] so 01:00 reads as -11, not +13. */
+function wrapHours(difference: number): number {
+  if (difference > 12) return difference - 24;
+  if (difference < -12) return difference + 24;
+  return difference;
+}
+
+/**
+ * Measures a file's daily rhythm against the contract.
+ *
+ * A conforming file records its daily codes at local noon. When they land
+ * elsewhere the timestamps are not on the clock the model declared, and the
+ * distance is the offset — which is usually enough to name the real zone. A
+ * file six hours ahead of Mountain Daylight Time is UTC.
+ *
+ * Returns null when no row carries codes; there is nothing to measure.
+ */
+export function describeDailyRhythm(
+  rows: CffdrsRow[],
+  timezone: string,
+): DailyRhythm | null {
+  const dailyHour = deriveDailyHour(rows, timezone);
+  if (dailyHour === null) return null;
+
+  // Measure against whichever contract hour is closer, so a daylight-time file
+  // at 13:00 reads as on-contract rather than an hour adrift.
+  const hoursFromNoon = CONTRACT_DAILY_HOURS
+    .map((contractHour) => wrapHours(dailyHour - contractHour))
+    .reduce((closest, candidate) =>
+      Math.abs(candidate) < Math.abs(closest) ? candidate : closest,
+    );
+
+  return {
+    dailyHour,
+    hoursFromNoon,
+    likelyZoneMismatch: hoursFromNoon !== 0,
+  };
+}

--- a/backend/src/infrastructure/weather/localCalendar.ts
+++ b/backend/src/infrastructure/weather/localCalendar.ts
@@ -1,0 +1,61 @@
+/**
+ * Local calendar helpers for daily fire weather codes — issue #352.
+ *
+ * DMC and DC are DAILY codes, defined by CFFDRS against noon LST conditions.
+ * Two things follow, and the previous implementation got both wrong:
+ *
+ *   1. They roll over on the LOCAL day boundary, not the UTC one. In Edmonton
+ *      UTC midnight falls at 18:00 the previous local day, so a single local
+ *      day was being split in two and updated twice.
+ *   2. They are driven by the observation nearest local NOON, not by whichever
+ *      row happens to come first in the day.
+ *
+ * The timezone contract (#354) makes this well defined: the CSV Date column is
+ * local time in the model's declared zone.
+ */
+
+import { DateTime } from 'luxon';
+
+/** Calendar day in the given zone, as YYYY-MM-DD. */
+export function localDayKey(instant: Date, timezone: string): string {
+  return DateTime.fromJSDate(instant, { zone: timezone }).toFormat('yyyy-MM-dd');
+}
+
+/** Calendar month in the given zone, 1-based, for the CFFDRS day-length term. */
+export function localMonth(instant: Date, timezone: string): number {
+  return DateTime.fromJSDate(instant, { zone: timezone }).month;
+}
+
+/** Noon, in hours, as CFFDRS defines the daily observation. */
+const NOON_HOUR = 12;
+
+/**
+ * For each local day, the index of the observation that should drive that day's
+ * DMC and DC — the one nearest local noon.
+ *
+ * Stations poll at :00, :05, :06 or :10, and files often start mid-morning, so
+ * an exact noon row cannot be assumed. Nearest-to-noon is always defined and
+ * degrades gracefully. Ties go to the earlier observation, which keeps the
+ * result deterministic.
+ */
+export function pickDailyDriverIndices(
+  instants: Date[],
+  timezone: string,
+): Map<string, number> {
+  const drivers = new Map<string, number>();
+  const distances = new Map<string, number>();
+
+  instants.forEach((instant, index) => {
+    const day = localDayKey(instant, timezone);
+    const local = DateTime.fromJSDate(instant, { zone: timezone });
+    const distance = Math.abs(local.hour + local.minute / 60 - NOON_HOUR);
+
+    const best = distances.get(day);
+    if (best === undefined || distance < best) {
+      distances.set(day, distance);
+      drivers.set(day, index);
+    }
+  });
+
+  return drivers;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.18",
+  "version": "0.14.19",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.12",
+  "version": "0.14.13",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.11",
+  "version": "0.14.12",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.14",
+  "version": "0.14.15",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.15",
+  "version": "0.14.16",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.13",
+  "version": "0.14.14",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.17",
+  "version": "0.14.18",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.16",
+  "version": "0.14.17",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,8 +151,13 @@ function AppContent() {
     setSubmitError(null);
 
     try {
-      // Request notification permission
-      await requestPermission();
+      // Ask for notification permission, but NEVER block submission on it (#358).
+      // This used to be awaited. If the user leaves the browser prompt sitting
+      // there the promise never settles, and since setIsSubmitting(true) has
+      // already run the UI hangs on "Submitting model..." forever with no
+      // timeout and no error. Notifications tell you when a model finishes;
+      // submitting the model is the actual work, and it must not wait on them.
+      void requestPermission();
 
       // Extract coordinates from geometry
       let coordinates: [number, number] | [number, number][] | [number, number][][] = [0, 0];

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import {
   JobStatusToast,
   NotificationPermissionBanner,
 } from './features/Notifications';
+import { resolveIgnitionLatitude } from './features/ModelSetup/utils/ignitionLatitude';
 import { runModel } from './services/api';
 import { registerServiceWorker } from './services/serviceWorker';
 import type { ModelResultsResponse } from './features/ModelReview/types';
@@ -229,9 +230,7 @@ function AppContent() {
             source: 'raw_weather',
             rawWeatherContent: await readFileContent(data.weather.rawWeatherFile),
             startingCodes: data.weather.startingCodes,
-            latitude: data.geometry.features[0]?.geometry?.type === 'Point'
-              ? (data.geometry.features[0].geometry.coordinates as [number, number])[1]
-              : data.geometry.bounds?.[1],
+            latitude: resolveIgnitionLatitude(data.geometry),
           };
           break;
         case 'spotwx': {
@@ -252,10 +251,7 @@ function AppContent() {
             source: 'raw_weather',
             rawWeatherContent: normalizeSpotwxToRawWeather(spotwxRaw),
             startingCodes: data.weather.startingCodes,
-            latitude:
-              data.geometry.features[0]?.geometry?.type === 'Point'
-                ? (data.geometry.features[0].geometry.coordinates as [number, number])[1]
-                : data.geometry.bounds?.[1],
+            latitude: resolveIgnitionLatitude(data.geometry),
           };
           break;
         }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import {
   NotificationPermissionBanner,
 } from './features/Notifications';
 import { resolveIgnitionLatitude } from './features/ModelSetup/utils/ignitionLatitude';
+import { resolveZonedInstant } from './features/ModelSetup/utils/zonedInstant';
 import { runModel } from './services/api';
 import { registerServiceWorker } from './services/serviceWorker';
 import type { ModelResultsResponse } from './features/ModelReview/types';
@@ -187,7 +188,12 @@ function AppContent() {
       }
 
       // Build time range
-      const startDateTime = new Date(`${data.temporal.startDate}T${data.temporal.startTime}`);
+      // Resolved in the model's own timezone, never the browser's (#355).
+      const startDateTime = resolveZonedInstant(
+        data.temporal.startDate,
+        data.temporal.startTime,
+        data.temporal.timezone,
+      );
       const endDateTime = new Date(startDateTime.getTime() + data.temporal.durationHours * 60 * 60 * 1000);
 
       // Helper to read file content

--- a/frontend/src/features/ModelReview/components/ResultsSummary.tsx
+++ b/frontend/src/features/ModelReview/components/ResultsSummary.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import type { ExecutionSummary, ExecutionState, ModelInputs, OutputConfig } from '../types';
 import { FuelVintageNotice } from '../../../shared/components/FuelVintageNotice';
-import { useFuelVintage } from '../../../shared/hooks/useFuelVintage';
+import { recordedToResolved } from '../../../shared/utils/fuelVintage';
 
 /**
  * Props for ResultsSummary
@@ -105,14 +105,13 @@ export function ResultsSummary({
 }: ResultsSummaryProps) {
   const ignition = inputs?.ignition;
 
-  // The year this fire was modelled FOR — not when it executed (#319).
-  // Absent when nothing on disk recorded it; the notice then renders nothing.
-  const modelYear = inputs?.modelStartDate
-    ? Number(inputs.modelStartDate.slice(0, 4))
-    : undefined;
-  const { resolved: fuelVintage } = useFuelVintage(
-    Number.isInteger(modelYear) ? modelYear : undefined
-  );
+  // The fuel vintage this run ACTUALLY used, as recorded when it ran (#331).
+  //
+  // This used to call useFuelVintage(), which re-resolved the vintage when the
+  // page was viewed — so installing a fuel year later retroactively rewrote
+  // what past runs claimed. A completed run is a record of what happened, so
+  // the results view reads the record and never re-resolves.
+  const fuelVintage = inputs?.fuelVintage;
   const statusInfo = getStatusInfo(summary.status);
   const isInProgress = ['queued', 'initializing', 'running'].includes(summary.status);
   const simLabel = outputConfig?.outputMode === 'deterministic'
@@ -359,7 +358,13 @@ export function ResultsSummary({
           border: '1px solid #e0e0e0',
           borderRadius: '6px',
         }}>
-          <FuelVintageNotice resolved={fuelVintage} label="Fuel vintage used" />
+          {fuelVintage ? (
+            <FuelVintageNotice resolved={recordedToResolved(fuelVintage)} label="Fuel vintage used" />
+          ) : (
+            <div style={{ fontSize: '0.8rem', color: '#6b7280' }}>
+              Fuel vintage: not recorded — this model ran before Nomad began recording it.
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/features/ModelReview/components/ResultsSummary.tsx
+++ b/frontend/src/features/ModelReview/components/ResultsSummary.tsx
@@ -350,8 +350,10 @@ export function ResultsSummary({
         </div>
       )}
 
-      {/* Fuel vintage actually used for this run (#319) */}
-      {fuelVintage && (
+      {/* Fuel vintage actually used for this run (#319, recorded per #331).
+          Rendered unconditionally: a run with NO record must say so rather than
+          silently omitting the row, which reads as "nothing to report". */}
+      {(
         <div style={{
           marginTop: '16px',
           padding: '12px',

--- a/frontend/src/features/ModelReview/components/__tests__/ResultsSummary.fuelVintage.test.tsx
+++ b/frontend/src/features/ModelReview/components/__tests__/ResultsSummary.fuelVintage.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * The results view reads the RECORDED fuel vintage — issue #331.
+ *
+ * It used to call useFuelVintage() and re-resolve when the page was viewed, so
+ * installing a fuel year later retroactively rewrote what past runs claimed to
+ * have used. A completed run is a record of what happened.
+ *
+ * These cover the display branch specifically, because it cannot be exercised
+ * end-to-end without a completed FireSTARR run.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ResultsSummary } from '../ResultsSummary.js';
+import type { ExecutionSummary, ModelInputs } from '../../types/index.js';
+
+const summary: ExecutionSummary = {
+  startedAt: '2026-08-19T12:00:00.000Z',
+  completedAt: '2026-08-19T12:10:00.000Z',
+  durationSeconds: 600,
+  status: 'completed',
+  progress: 100,
+};
+
+function renderWith(inputs?: ModelInputs) {
+  return render(
+    <ResultsSummary
+      modelId="m1"
+      modelName="Hay River"
+      engineType="firestarr"
+      userId="tester"
+      summary={summary}
+      outputCount={3}
+      inputs={inputs}
+    />,
+  );
+}
+
+describe('ResultsSummary — recorded fuel vintage (#331)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // If anything re-resolves the vintage at view time, this catches it.
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ datasets: [], resolved: undefined }) });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('shows the vintage the run recorded', () => {
+    renderWith({
+      modelStartDate: '2026-06-19T18:00:00.000Z',
+      fuelVintage: {
+        requestedYear: 2026, vintage: '2026',
+        matchedRequestedYear: true, usedFallback: false,
+      },
+    } as ModelInputs);
+
+    expect(document.body.textContent).toMatch(/2026/);
+    expect(document.body.textContent).not.toMatch(/not recorded/i);
+  });
+
+  it('admits when a default dataset stood in for the requested year', () => {
+    renderWith({
+      modelStartDate: '2024-06-19T18:00:00.000Z',
+      fuelVintage: {
+        requestedYear: 2024, vintage: 'default',
+        matchedRequestedYear: false, usedFallback: true,
+      },
+    } as ModelInputs);
+
+    // The silent {year}/ -> default/ substitution is what the output depended on.
+    expect(document.body.textContent).toMatch(/2024/);
+  });
+
+  it('says "not recorded" for a run that predates the recording', () => {
+    // Must NOT infer one. Installing 2024 tomorrow cannot change what a run
+    // from last year used.
+    renderWith({ modelStartDate: '2024-06-19T18:00:00.000Z' } as ModelInputs);
+
+    expect(document.body.textContent).toMatch(/not recorded/i);
+  });
+
+  it('never re-resolves the vintage at view time', () => {
+    renderWith({ modelStartDate: '2024-06-19T18:00:00.000Z' } as ModelInputs);
+
+    const fuelCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('fuel-dataset'));
+    expect(fuelCalls).toEqual([]);
+  });
+});

--- a/frontend/src/features/ModelReview/types/index.ts
+++ b/frontend/src/features/ModelReview/types/index.ts
@@ -89,6 +89,21 @@ export interface ModelInputs {
    * Absent when nothing on disk records it.
    */
   modelStartDate?: string;
+  /**
+   * The fuel vintage the run actually used, recorded when it ran (#331).
+   *
+   * Absent for runs predating the recording. The results view must display
+   * "not recorded" in that case rather than re-resolving: installing a fuel
+   * year later must not rewrite what a past run claims to have used.
+   */
+  fuelVintage?: {
+    requestedYear: number;
+    vintage: string;
+    matchedRequestedYear: boolean;
+    usedFallback: boolean;
+    gridPath?: string;
+    recordedAt?: string;
+  };
 }
 
 /**

--- a/frontend/src/features/ModelSetup/components/FirestarrCsvUpload.tsx
+++ b/frontend/src/features/ModelSetup/components/FirestarrCsvUpload.tsx
@@ -303,8 +303,26 @@ export function FirestarrCsvUpload({ onUpload, fileName, parsed, error }: Firest
         </div>
       )}
 
+      {/* Missing FWI VALUES — the columns can all be present and still hold nothing (#357) */}
+      {hasFile && !displayError && (parsed?.fwiValues?.rowsMissingCodes ?? 0) > 0 && (
+        <div style={warningStyle}>
+          <strong>This file is missing FWI values</strong> - {parsed!.fwiValues!.rowsMissingCodes} of{' '}
+          {parsed!.fwiValues!.totalRows} rows have no FFMC, DMC or DC. FireSTARR needs them on every
+          row.
+          {parsed!.fwiValues!.rowsWithAllCodes > 0 && (
+            <>
+              {' '}
+              Only {parsed!.fwiValues!.rowsWithAllCodes} row
+              {parsed!.fwiValues!.rowsWithAllCodes === 1 ? ' does' : 's do'} — which usually means the
+              indices were recorded once a day rather than hourly. Nomad will offer to use those daily
+              codes as starting codes when you start the model.
+            </>
+          )}
+        </div>
+      )}
+
       {/* Success message */}
-      {hasFile && !displayError && (
+      {hasFile && !displayError && (parsed?.fwiValues?.rowsMissingCodes ?? 0) === 0 && (
         <div style={successStyle}>
           <strong>Valid FireSTARR weather file</strong> - {parsed?.rowCount} hourly records with all
           required columns including FWI indices.

--- a/frontend/src/features/ModelSetup/components/ModelSetupWizard.tsx
+++ b/frontend/src/features/ModelSetup/components/ModelSetupWizard.tsx
@@ -269,6 +269,8 @@ export function ModelSetupWizard({ onComplete, onCancel, draftId, topGutter = 0 
       {gate && (
         <StartingCodesModal
           candidate={gate.candidate}
+          rhythm={gate.rhythm}
+          timezone={gate.timezone}
           onConfirm={gate.confirm}
           onCancel={gate.cancel}
         />

--- a/frontend/src/features/ModelSetup/components/ModelSetupWizard.tsx
+++ b/frontend/src/features/ModelSetup/components/ModelSetupWizard.tsx
@@ -20,6 +20,9 @@ import {
   useWizard,
 } from '../../Wizard';
 import { useModelSetup } from '../hooks/useModelSetup';
+import { useWeatherPreflightGate } from '../hooks/useWeatherPreflightGate';
+import { StartingCodesModal } from './StartingCodesModal';
+import { PreflightErrorModal } from './PreflightErrorModal';
 import { DrawingToolbar } from '../../Map';
 import { SpatialInputStep } from '../steps/SpatialInputStep';
 import { TemporalStep } from '../steps/TemporalStep';
@@ -241,17 +244,42 @@ export function ModelSetupWizard({ onComplete, onCancel, draftId, topGutter = 0 
     y: initialDimensions.y,
   });
 
+  // Weather pre-flight (#351). A FireSTARR CSV that records its CFFDRS indices
+  // once a day writes NaN onto the FireSTARR command line and segfaults the
+  // engine. The gate holds the submission, offers the codes already in the
+  // user's file, and only calls onComplete on an explicit yes.
+  //
+  // It sits here rather than in App.tsx because App.tsx is only the SAN
+  // reference implementation — the wizard forwards to a host-supplied
+  // onComplete, so gating here protects ACN integrators too.
+  const { guardedComplete, gate, error: preflightError } = useWeatherPreflightGate(onComplete);
+
+  const [dismissedError, setDismissedError] = useState(false);
+
   const handleComplete = useCallback(
     async (data: ModelSetupData) => {
-      console.log('Model setup complete:', data);
-
-      // For MVP, just log the data
-      // In Phase 6, this will call the backend API
-      if (onComplete) {
-        await onComplete(data);
-      }
+      setDismissedError(false);
+      await guardedComplete(data);
     },
-    [onComplete]
+    [guardedComplete]
+  );
+
+  const preflightOverlay = (
+    <>
+      {gate && (
+        <StartingCodesModal
+          candidate={gate.candidate}
+          onConfirm={gate.confirm}
+          onCancel={gate.cancel}
+        />
+      )}
+      {preflightError && !dismissedError && (
+        <PreflightErrorModal
+          message={preflightError}
+          onDismiss={() => setDismissedError(true)}
+        />
+      )}
+    </>
   );
 
   const handleCancel = useCallback(() => {
@@ -269,6 +297,7 @@ export function ModelSetupWizard({ onComplete, onCancel, draftId, topGutter = 0 
   if (isMobile) {
     return (
       <>
+        {preflightOverlay}
       <DrawingToolbar position="bottom-left" />
       <div
         style={{
@@ -335,6 +364,7 @@ export function ModelSetupWizard({ onComplete, onCancel, draftId, topGutter = 0 
   if (isTablet) {
     return (
       <>
+        {preflightOverlay}
       <DrawingToolbar position="bottom-left" />
       <div style={{
         position: 'fixed',
@@ -392,6 +422,7 @@ export function ModelSetupWizard({ onComplete, onCancel, draftId, topGutter = 0 
   // Desktop: draggable/resizable panel
   return (
     <>
+    {preflightOverlay}
     <DrawingToolbar position="bottom-left" />
     <Rnd
       default={{

--- a/frontend/src/features/ModelSetup/components/PreflightErrorModal.tsx
+++ b/frontend/src/features/ModelSetup/components/PreflightErrorModal.tsx
@@ -1,0 +1,49 @@
+/**
+ * Pre-flight failure — issue #351.
+ *
+ * Shown when the weather check itself could not complete. Submission is blocked
+ * rather than allowed through: the check exists to prevent a segfault, so
+ * proceeding while its result is unknown would defeat it. The user sees why.
+ */
+
+import {
+  overlayStyle,
+  modalStyle,
+  noteStyle,
+  codesStyle,
+  actionsStyle,
+  cancelStyle,
+} from './preflightModalStyles.js';
+
+export interface PreflightErrorModalProps {
+  message: string;
+  onDismiss: () => void;
+}
+
+export function PreflightErrorModal({ message, onDismiss }: PreflightErrorModalProps) {
+  return (
+    <div style={overlayStyle} role="dialog" aria-modal="true" aria-label="Weather check failed">
+      <div style={modalStyle}>
+        <h2 style={{ margin: 0, fontSize: '1.25rem' }}>Nomad could not check this weather file</h2>
+
+        <p style={noteStyle}>
+          The model was not started. Nothing was created, so nothing needs cleaning up.
+        </p>
+
+        <div style={{ ...codesStyle, fontWeight: 400, fontSize: '0.9rem', textAlign: 'left' }}>
+          {message}
+        </div>
+
+        <p style={noteStyle}>
+          Fix the file and try again, or choose a different weather source.
+        </p>
+
+        <div style={actionsStyle}>
+          <button type="button" style={cancelStyle} onClick={onDismiss}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/ModelSetup/components/StartingCodesModal.tsx
+++ b/frontend/src/features/ModelSetup/components/StartingCodesModal.tsx
@@ -22,11 +22,35 @@ import {
   cancelStyle,
 } from './preflightModalStyles.js';
 
+export interface DailyRhythm {
+  dailyHour: number;
+  hoursFromNoon: number;
+  likelyZoneMismatch: boolean;
+}
+
 export interface StartingCodesModalProps {
   /** The reading recovered from the file, or null when none precedes ignition. */
   candidate: StartingCodeCandidate | null;
+  /** How the file's rhythm compares with the contract (#354). */
+  rhythm?: DailyRhythm | null;
+  /** The model's declared IANA zone, named back to the user. */
+  timezone?: string;
   onConfirm: () => void;
   onCancel: () => void;
+}
+
+/** The declared zone's offset from UTC, in hours, right now. */
+function zoneOffsetHours(timeZone: string): number | null {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-CA', { timeZone, timeZoneName: 'longOffset' });
+    const name = formatter.formatToParts(new Date()).find((p) => p.type === 'timeZoneName')?.value;
+    const match = /GMT([+-])(\d{2}):(\d{2})/.exec(name ?? '');
+    if (!match) return 0; // "GMT" with no suffix is UTC itself
+    const sign = match[1] === '-' ? -1 : 1;
+    return sign * (Number(match[2]) + Number(match[3]) / 60);
+  } catch {
+    return null;
+  }
 }
 
 /** Two decimals, so 424.9 reads as 424.90 alongside the others. */
@@ -34,7 +58,40 @@ function code(value: number): string {
   return value.toFixed(2);
 }
 
-export function StartingCodesModal({ candidate, onConfirm, onCancel }: StartingCodesModalProps) {
+/**
+ * Explains a rhythm that does not sit at local noon.
+ *
+ * The contract (#354) is that the Date column is local time in the model's
+ * timezone, and daily codes are recorded at noon. When the file's readings land
+ * elsewhere, the gap IS the offset — and if it matches the declared zone's own
+ * offset from UTC, the file is almost certainly UTC.
+ */
+function zoneNote(rhythm: DailyRhythm, timezone?: string): string {
+  const hours = Math.abs(rhythm.hoursFromNoon);
+  const direction = rhythm.hoursFromNoon > 0 ? 'ahead of' : 'behind';
+  const zone = timezone ?? 'the selected timezone';
+  const hourLabel = `${String(rhythm.dailyHour).padStart(2, '0')}:00`;
+
+  const offset = timezone ? zoneOffsetHours(timezone) : null;
+  const looksLikeUtc = offset !== null && Math.abs(rhythm.hoursFromNoon + offset) < 0.5;
+
+  const base =
+    `Its daily readings sit at ${hourLabel} in ${zone}, but daily codes are recorded at noon — ` +
+    `${hours} hours ${direction} the timezone this model declares.`;
+
+  return looksLikeUtc
+    ? `${base} That gap matches ${zone}'s offset exactly, so these timestamps are most likely UTC. ` +
+      `If they are, set the model timezone to UTC before running.`
+    : `${base} Check that the model timezone matches the clock your station records in.`;
+}
+
+export function StartingCodesModal({
+  candidate,
+  rhythm,
+  timezone,
+  onConfirm,
+  onCancel,
+}: StartingCodesModalProps) {
   return (
     <div style={overlayStyle} role="dialog" aria-modal="true" aria-label="Starting codes">
       <div style={modalStyle}>
@@ -66,6 +123,12 @@ export function StartingCodesModal({ candidate, onConfirm, onCancel }: StartingC
             Nomad could not offer starting codes: this file has no daily reading{' '}
             <strong>before</strong> your ignition time. Choose an ignition time covered by the file,
             or upload raw observations with the starting codes you want to use.
+          </p>
+        )}
+
+        {rhythm?.likelyZoneMismatch && (
+          <p style={{ ...noteStyle, color: '#fbbf24' }}>
+            {zoneNote(rhythm, timezone)}
           </p>
         )}
 

--- a/frontend/src/features/ModelSetup/components/StartingCodesModal.tsx
+++ b/frontend/src/features/ModelSetup/components/StartingCodesModal.tsx
@@ -1,0 +1,85 @@
+/**
+ * Starting-codes confirmation — issue #351.
+ *
+ * A weather file with CFFDRS values on daily rows only satisfies neither
+ * supported contract, and uploading it segfaults the engine. But the user
+ * already has what Nomad needs: the noon reading is in the file. This states
+ * what was found, in real numbers, and asks.
+ *
+ * Styling follows the house pattern (see AboutModal) — inline style objects as
+ * module-level consts. There is no shared dialog primitive in this codebase;
+ * every modal hand-rolls its own overlay.
+ */
+
+import type { StartingCodeCandidate } from '../utils/weatherPreflight.js';
+import {
+  overlayStyle,
+  modalStyle,
+  codesStyle,
+  noteStyle,
+  actionsStyle,
+  confirmStyle,
+  cancelStyle,
+} from './preflightModalStyles.js';
+
+export interface StartingCodesModalProps {
+  /** The reading recovered from the file, or null when none precedes ignition. */
+  candidate: StartingCodeCandidate | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/** Two decimals, so 424.9 reads as 424.90 alongside the others. */
+function code(value: number): string {
+  return value.toFixed(2);
+}
+
+export function StartingCodesModal({ candidate, onConfirm, onCancel }: StartingCodesModalProps) {
+  return (
+    <div style={overlayStyle} role="dialog" aria-modal="true" aria-label="Starting codes">
+      <div style={modalStyle}>
+        <h2 style={{ margin: 0, fontSize: '1.25rem' }}>This weather file records its indices once a day</h2>
+
+        <p style={noteStyle}>
+          Nomad accepts two shapes: a FireSTARR file with hourly CFFDRS values on{' '}
+          <strong>every</strong> row, or raw observations plus starting codes. Yours records the
+          indices on the daily reading only, so the remaining hours have no values.
+        </p>
+
+        {candidate ? (
+          <>
+            <div style={codesStyle}>
+              Nomad found starting codes in your file:
+              <br />
+              FFMC {code(candidate.ffmc)}, DMC {code(candidate.dmc)}, DC {code(candidate.dc)}
+              <br />
+              from {candidate.localLabel}
+            </div>
+
+            <p style={noteStyle}>
+              This is the last daily reading before your ignition time. Use these as the starting
+              codes and Nomad will calculate the remaining hours from your observations.
+            </p>
+          </>
+        ) : (
+          <p style={noteStyle}>
+            Nomad could not offer starting codes: this file has no daily reading{' '}
+            <strong>before</strong> your ignition time. Choose an ignition time covered by the file,
+            or upload raw observations with the starting codes you want to use.
+          </p>
+        )}
+
+        <div style={actionsStyle}>
+          <button type="button" style={cancelStyle} onClick={onCancel}>
+            Cancel
+          </button>
+          {candidate && (
+            <button type="button" style={confirmStyle} onClick={onConfirm}>
+              Use these codes
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/ModelSetup/components/__tests__/PreflightErrorModal.test.tsx
+++ b/frontend/src/features/ModelSetup/components/__tests__/PreflightErrorModal.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PreflightErrorModal } from '../PreflightErrorModal.js';
+
+describe('PreflightErrorModal', () => {
+  it("shows the parser's own reason rather than a generic apology", () => {
+    render(<PreflightErrorModal message='Required column "date" not found in CSV' onDismiss={vi.fn()} />);
+    expect(screen.getByText(/Required column "date" not found/)).toBeTruthy();
+  });
+
+  it('says plainly that nothing was created', () => {
+    render(<PreflightErrorModal message="boom" onDismiss={vi.fn()} />);
+    expect(document.body.textContent).toMatch(/not started|nothing was created/i);
+  });
+
+  it('dismisses without submitting anything', async () => {
+    const onDismiss = vi.fn();
+    render(<PreflightErrorModal message="boom" onDismiss={onDismiss} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/ModelSetup/components/__tests__/StartingCodesModal.test.tsx
+++ b/frontend/src/features/ModelSetup/components/__tests__/StartingCodesModal.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Starting-codes confirmation — issue #351.
+ *
+ * The user's file has the codes. This asks whether to use them, states plainly
+ * what was found, and makes declining a real option that costs nothing.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StartingCodesModal } from '../StartingCodesModal.js';
+import type { StartingCodeCandidate } from '../../utils/weatherPreflight.js';
+
+const CANDIDATE: StartingCodeCandidate = {
+  ffmc: 84.65,
+  dmc: 20.72,
+  dc: 424.9,
+  observedAt: '2026-08-04T01:06:00.000Z',
+  localLabel: '2026-08-03, 1900',
+};
+
+describe('StartingCodesModal', () => {
+  it('states the actual numbers found, not a vague reassurance', () => {
+    render(<StartingCodesModal candidate={CANDIDATE} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByText(/84\.65/)).toBeTruthy();
+    expect(screen.getByText(/20\.72/)).toBeTruthy();
+    expect(screen.getByText(/424\.9/)).toBeTruthy();
+  });
+
+  it('names when the reading was taken so the user can find it in their file', () => {
+    render(<StartingCodesModal candidate={CANDIDATE} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByText(/2026-08-03, 1900/)).toBeTruthy();
+  });
+
+  it('explains the two supported shapes rather than just refusing', () => {
+    render(<StartingCodesModal candidate={CANDIDATE} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+    const text = document.body.textContent ?? '';
+    expect(text).toMatch(/hourly/i);
+    expect(text).toMatch(/starting codes/i);
+  });
+
+  it('uses the codes when the user accepts', async () => {
+    const onConfirm = vi.fn();
+    render(<StartingCodesModal candidate={CANDIDATE} onConfirm={onConfirm} onCancel={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /use these/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('abandons the run when the user declines', async () => {
+    const onCancel = vi.fn();
+    render(<StartingCodesModal candidate={CANDIDATE} onConfirm={vi.fn()} onCancel={onCancel} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when the file has the shape but no usable reading', () => {
+    it('offers no confirm button — there is nothing to accept', () => {
+      render(<StartingCodesModal candidate={null} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+      expect(screen.queryByRole('button', { name: /use these/i })).toBeNull();
+    });
+
+    it('says why, rather than failing silently', () => {
+      render(<StartingCodesModal candidate={null} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+      const text = document.body.textContent ?? '';
+      expect(text).toMatch(/before/i);
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/features/ModelSetup/components/__tests__/StartingCodesModal.test.tsx
+++ b/frontend/src/features/ModelSetup/components/__tests__/StartingCodesModal.test.tsx
@@ -20,6 +20,9 @@ const CANDIDATE: StartingCodeCandidate = {
   localLabel: '2026-08-03, 1900',
 };
 
+const MISMATCH = { dailyHour: 19, hoursFromNoon: 6, likelyZoneMismatch: true };
+const ON_CONTRACT = { dailyHour: 13, hoursFromNoon: 0, likelyZoneMismatch: false };
+
 describe('StartingCodesModal', () => {
   it('states the actual numbers found, not a vague reassurance', () => {
     render(<StartingCodesModal candidate={CANDIDATE} onConfirm={vi.fn()} onCancel={vi.fn()} />);
@@ -72,6 +75,68 @@ describe('StartingCodesModal', () => {
       const text = document.body.textContent ?? '';
       expect(text).toMatch(/before/i);
       expect(screen.getByRole('button', { name: /cancel/i })).toBeTruthy();
+    });
+  });
+
+  describe('timezone contract (#354)', () => {
+    it('warns when the file sits away from local noon, naming the gap', () => {
+      // Daily codes are recorded at noon local. Hers read 19:00 in Edmonton —
+      // six hours ahead, which is exactly UTC.
+      render(
+        <StartingCodesModal
+          candidate={CANDIDATE}
+          rhythm={MISMATCH}
+          timezone="America/Edmonton"
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      const text = document.body.textContent ?? '';
+      expect(text).toMatch(/6 hours ahead/i);
+      expect(text).toMatch(/America\/Edmonton/);
+    });
+
+    it('names UTC as the likely cause when the gap matches the zone offset', () => {
+      render(
+        <StartingCodesModal
+          candidate={CANDIDATE}
+          rhythm={MISMATCH}
+          timezone="America/Edmonton"
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      expect(document.body.textContent).toMatch(/UTC/);
+    });
+
+    it('says nothing about timezones when the file is on contract', () => {
+      render(
+        <StartingCodesModal
+          candidate={CANDIDATE}
+          rhythm={ON_CONTRACT}
+          timezone="America/Edmonton"
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      expect(document.body.textContent).not.toMatch(/hours ahead|hours behind/i);
+    });
+
+    it('says nothing when there is no rhythm to report', () => {
+      render(
+        <StartingCodesModal
+          candidate={CANDIDATE}
+          rhythm={null}
+          timezone="America/Edmonton"
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      expect(document.body.textContent).not.toMatch(/hours ahead|hours behind/i);
     });
   });
 });

--- a/frontend/src/features/ModelSetup/components/preflightModalStyles.ts
+++ b/frontend/src/features/ModelSetup/components/preflightModalStyles.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared styling for the pre-flight dialogs — issue #351.
+ *
+ * Follows the house pattern (see AboutModal): inline style objects as
+ * module-level consts. There is no shared dialog primitive in this codebase;
+ * every modal hand-rolls its own overlay, so these are shared between the two
+ * pre-flight dialogs rather than duplicated.
+ */
+
+import type React from 'react';
+
+export const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0,0,0,0.5)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 20000,
+};
+
+export const modalStyle: React.CSSProperties = {
+  backgroundColor: '#1f2937',
+  color: 'white',
+  borderRadius: '12px',
+  padding: '32px',
+  width: 'calc(100% - 32px)',
+  maxWidth: '520px',
+  boxSizing: 'border-box',
+  boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+};
+
+export const codesStyle: React.CSSProperties = {
+  backgroundColor: '#111827',
+  borderRadius: '8px',
+  padding: '16px',
+  margin: '16px 0',
+  fontSize: '1.05rem',
+  fontWeight: 600,
+  textAlign: 'center',
+};
+
+export const noteStyle: React.CSSProperties = {
+  fontSize: '0.875rem',
+  color: '#9ca3af',
+  lineHeight: 1.5,
+};
+
+export const actionsStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '12px',
+  justifyContent: 'flex-end',
+  marginTop: '24px',
+  flexWrap: 'wrap',
+};
+
+export const buttonStyle: React.CSSProperties = {
+  padding: '10px 20px',
+  borderRadius: '8px',
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: '0.95rem',
+};
+
+export const confirmStyle: React.CSSProperties = {
+  ...buttonStyle,
+  backgroundColor: '#2563eb',
+  color: 'white',
+  fontWeight: 600,
+};
+
+export const cancelStyle: React.CSSProperties = {
+  ...buttonStyle,
+  backgroundColor: 'transparent',
+  color: '#d1d5db',
+  border: '1px solid #4b5563',
+};
+

--- a/frontend/src/features/ModelSetup/hooks/__tests__/useWeatherPreflightGate.test.ts
+++ b/frontend/src/features/ModelSetup/hooks/__tests__/useWeatherPreflightGate.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The submit gate — issue #351.
+ *
+ * Sits between the wizard finishing and onComplete firing. If the uploaded
+ * weather has the daily-only CFFDRS shape it holds the submission, offers the
+ * codes found in the user's own file, and only proceeds on an explicit yes.
+ *
+ * Extracted from ModelSetupWizard so the state machine is testable: no harness
+ * exists for the wizard's submit path, and driving the whole wizard through
+ * every step to reach it would test the steps, not this.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useWeatherPreflightGate } from '../useWeatherPreflightGate.js';
+import type { ModelSetupData } from '../../types/index.js';
+
+const CANDIDATE = {
+  ffmc: 84.65,
+  dmc: 20.72,
+  dc: 424.9,
+  observedAt: '2026-08-04T01:06:00.000Z',
+  localLabel: '2026-08-03, 1900',
+};
+
+function csvFile(): File {
+  return new File(['Scenario,Date\n0,2026-08-01 00:06:00'], 'station.csv', { type: 'text/csv' });
+}
+
+function firestarrData(): ModelSetupData {
+  return {
+    geometry: {},
+    temporal: {
+      startDate: '2026-08-04',
+      startTime: '12:00',
+      durationHours: 72,
+      timezone: 'America/Edmonton',
+      isForecast: false,
+    },
+    model: {},
+    weather: {
+      source: 'firestarr_csv',
+      firestarrCsvFile: csvFile(),
+      firestarrCsvFileName: 'station.csv',
+    },
+  } as unknown as ModelSetupData;
+}
+
+describe('useWeatherPreflightGate', () => {
+  let onComplete: ReturnType<typeof vi.fn>;
+  let preflight: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onComplete = vi.fn();
+    preflight = vi.fn().mockResolvedValue({ dailyOnlyCffdrs: false, candidate: null });
+  });
+
+  function setup() {
+    return renderHook(() => useWeatherPreflightGate(onComplete, { preflight }));
+  }
+
+  it('submits straight through when the file is fine', async () => {
+    const { result } = setup();
+    const data = firestarrData();
+
+    await act(async () => {
+      await result.current.guardedComplete(data);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith(data);
+    expect(result.current.gate).toBeNull();
+  });
+
+  it('skips the round-trip entirely for a source that cannot have the shape', async () => {
+    const { result } = setup();
+    const data = { ...firestarrData(), weather: { source: 'spotwx' as const, spotwxFile: csvFile() } };
+
+    await act(async () => {
+      await result.current.guardedComplete(data as ModelSetupData);
+    });
+
+    expect(preflight).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when the daily-only shape is found', () => {
+    beforeEach(() => {
+      preflight.mockResolvedValue({ dailyOnlyCffdrs: true, candidate: CANDIDATE });
+    });
+
+    it('HOLDS the submission — onComplete must not fire behind the question', async () => {
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.guardedComplete(firestarrData());
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(result.current.gate?.candidate).toEqual(CANDIDATE);
+    });
+
+    it('submits on the raw_weather path with the recovered codes when accepted', async () => {
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.guardedComplete(firestarrData());
+      });
+      await act(async () => {
+        await result.current.gate!.confirm();
+      });
+
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      const submitted = onComplete.mock.calls[0][0] as ModelSetupData;
+      expect(submitted.weather.source).toBe('raw_weather');
+      expect(submitted.weather.startingCodes).toEqual({ ffmc: 84.65, dmc: 20.72, dc: 424.9 });
+    });
+
+    it('abandons cleanly when declined — nothing submitted, nothing created', async () => {
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.guardedComplete(firestarrData());
+      });
+      act(() => {
+        result.current.gate!.cancel();
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+      await waitFor(() => expect(result.current.gate).toBeNull());
+    });
+
+    it('sends the file content and the ignition instant to the check', async () => {
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.guardedComplete(firestarrData());
+      });
+
+      const sent = preflight.mock.calls[0][0];
+      expect(sent.weather.firestarrCsvContent).toContain('Scenario,Date');
+      expect(sent.timezone).toBe('America/Edmonton');
+      expect(sent.timeRange.start).toMatch(/Z$|[+-]\d{2}:\d{2}$/);
+    });
+  });
+
+  it('opens the gate with no candidate when the shape is found but nothing precedes ignition', async () => {
+    preflight.mockResolvedValue({ dailyOnlyCffdrs: true, candidate: null });
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.guardedComplete(firestarrData());
+    });
+
+    expect(result.current.gate).not.toBeNull();
+    expect(result.current.gate?.candidate).toBeNull();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('blocks submission when the check itself fails, rather than guessing', async () => {
+    // Fail-fast. The check exists to stop a segfault; proceeding while its
+    // result is unknown defeats the point.
+    preflight.mockRejectedValue(new Error('Required column "date" not found in CSV'));
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.guardedComplete(firestarrData());
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(result.current.error).toMatch(/date/);
+  });
+});

--- a/frontend/src/features/ModelSetup/hooks/__tests__/useWeatherPreflightGate.test.ts
+++ b/frontend/src/features/ModelSetup/hooks/__tests__/useWeatherPreflightGate.test.ts
@@ -129,6 +129,24 @@ describe('useWeatherPreflightGate', () => {
       await waitFor(() => expect(result.current.gate).toBeNull());
     });
 
+    it('carries the rhythm and the declared zone into the question', async () => {
+      // The user is told how far their file sits from the contract (#354),
+      // named against the zone they chose.
+      preflight.mockResolvedValue({
+        dailyOnlyCffdrs: true,
+        candidate: CANDIDATE,
+        rhythm: { dailyHour: 19, hoursFromNoon: 6, likelyZoneMismatch: true },
+      });
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.guardedComplete(firestarrData());
+      });
+
+      expect(result.current.gate?.rhythm?.hoursFromNoon).toBe(6);
+      expect(result.current.gate?.timezone).toBe('America/Edmonton');
+    });
+
     it('sends the file content and the ignition instant to the check', async () => {
       const { result } = setup();
 

--- a/frontend/src/features/ModelSetup/hooks/useWeatherPreflightGate.ts
+++ b/frontend/src/features/ModelSetup/hooks/useWeatherPreflightGate.ts
@@ -18,7 +18,12 @@
  */
 
 import { useCallback, useState } from 'react';
-import { preflightWeather as defaultPreflight, type PreflightRequest, type PreflightResponse } from '../../../services/api.js';
+import {
+  preflightWeather as defaultPreflight,
+  type PreflightRequest,
+  type PreflightResponse,
+  type PreflightRhythm,
+} from '../../../services/api.js';
 import {
   needsPreflight,
   buildIgnitionInstant,
@@ -32,6 +37,10 @@ import type { ModelSetupData } from '../types/index.js';
 export interface PreflightGate {
   /** What was found, or null when nothing precedes ignition. */
   candidate: StartingCodeCandidate | null;
+  /** How the file's rhythm compares with the timezone contract (#354). */
+  rhythm: PreflightRhythm | null;
+  /** The model's declared zone, so the question can name it back to the user. */
+  timezone: string;
   /** Accept the codes and submit on the raw_weather path. */
   confirm: () => Promise<void>;
   /** Abandon. Nothing was created, so there is nothing to clean up. */
@@ -103,6 +112,8 @@ export function useWeatherPreflightGate(
 
       setGate({
         candidate: result.candidate,
+        rhythm: result.rhythm,
+        timezone: data.temporal.timezone,
         confirm: async () => {
           setGate(null);
           if (result.candidate) {

--- a/frontend/src/features/ModelSetup/hooks/useWeatherPreflightGate.ts
+++ b/frontend/src/features/ModelSetup/hooks/useWeatherPreflightGate.ts
@@ -1,0 +1,119 @@
+/**
+ * Submit gate for daily-only CFFDRS weather — issue #351.
+ *
+ * Sits between the wizard finishing and onComplete firing. When the uploaded
+ * FireSTARR CSV records its indices once a day, submitting it as-is writes NaN
+ * onto the FireSTARR command line and segfaults the engine. The codes are in
+ * the file, so we hold the submission, offer what we found, and proceed only on
+ * an explicit yes.
+ *
+ * This lives inside features/ModelSetup/ deliberately. The wizard forwards to a
+ * host-supplied onComplete — App.tsx is only the SAN reference implementation —
+ * so gating here reaches every consumer, including ACN integrators, without
+ * changing any exported prop signature.
+ *
+ * The check runs at submit rather than at upload because the reading offered is
+ * the last one before ignition. An answer given at upload goes stale the moment
+ * the user changes the ignition time.
+ */
+
+import { useCallback, useState } from 'react';
+import { preflightWeather as defaultPreflight, type PreflightRequest, type PreflightResponse } from '../../../services/api.js';
+import {
+  needsPreflight,
+  buildIgnitionInstant,
+  applyStartingCodes,
+  readFileText,
+  type StartingCodeCandidate,
+} from '../utils/weatherPreflight.js';
+import type { ModelSetupData } from '../types/index.js';
+
+/** The held submission, surfaced so the wizard can render the question. */
+export interface PreflightGate {
+  /** What was found, or null when nothing precedes ignition. */
+  candidate: StartingCodeCandidate | null;
+  /** Accept the codes and submit on the raw_weather path. */
+  confirm: () => Promise<void>;
+  /** Abandon. Nothing was created, so there is nothing to clean up. */
+  cancel: () => void;
+}
+
+interface Deps {
+  preflight?: (body: PreflightRequest) => Promise<PreflightResponse>;
+}
+
+export interface UseWeatherPreflightGateReturn {
+  /** Drop-in replacement for the wizard's completion handler. */
+  guardedComplete: (data: ModelSetupData) => Promise<void>;
+  /** Non-null while the user is being asked. */
+  gate: PreflightGate | null;
+  /** Set when the check itself failed. Submission is blocked, not guessed. */
+  error: string | null;
+}
+
+export function useWeatherPreflightGate(
+  onComplete: ((data: ModelSetupData) => void | Promise<void>) | undefined,
+  deps: Deps = {},
+): UseWeatherPreflightGateReturn {
+  const preflight = deps.preflight ?? defaultPreflight;
+
+  const [gate, setGate] = useState<PreflightGate | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const guardedComplete = useCallback(
+    async (data: ModelSetupData) => {
+      setError(null);
+
+      // raw_weather already carries explicit starting codes and spotwx is
+      // generated, so neither is worth a round-trip.
+      if (!needsPreflight(data.weather)) {
+        await onComplete?.(data);
+        return;
+      }
+
+      const file = data.weather.firestarrCsvFile;
+      if (!file) {
+        await onComplete?.(data);
+        return;
+      }
+
+      let result: PreflightResponse;
+      try {
+        const start = buildIgnitionInstant(data.temporal);
+        const end = new Date(
+          new Date(start).getTime() + data.temporal.durationHours * 60 * 60 * 1000,
+        ).toISOString();
+
+        result = await preflight({
+          timezone: data.temporal.timezone,
+          timeRange: { start, end },
+          weather: { source: 'firestarr_csv', firestarrCsvContent: await readFileText(file) },
+        });
+      } catch (e) {
+        // Fail-fast: the check exists to prevent a segfault, so proceeding
+        // while its result is unknown would defeat it.
+        setError(e instanceof Error ? e.message : String(e));
+        return;
+      }
+
+      if (!result.dailyOnlyCffdrs) {
+        await onComplete?.(data);
+        return;
+      }
+
+      setGate({
+        candidate: result.candidate,
+        confirm: async () => {
+          setGate(null);
+          if (result.candidate) {
+            await onComplete?.(applyStartingCodes(data, result.candidate));
+          }
+        },
+        cancel: () => setGate(null),
+      });
+    },
+    [onComplete, preflight],
+  );
+
+  return { guardedComplete, gate, error };
+}

--- a/frontend/src/features/ModelSetup/types/index.ts
+++ b/frontend/src/features/ModelSetup/types/index.ts
@@ -135,6 +135,17 @@ export interface ParsedWeatherCSV {
   hasScenarioColumn: boolean;
   /** Whether all FWI columns are present (FFMC, DMC, DC, ISI, BUI, FWI) */
   hasFWIColumns: boolean;
+  /**
+   * What those columns actually CONTAIN (#357). hasFWIColumns only reports that
+   * the headers exist — a file can carry every column and still hold nothing.
+   * Undefined for files with no FWI columns at all.
+   */
+  fwiValues?: {
+    totalRows: number;
+    rowsWithAllCodes: number;
+    rowsMissingCodes: number;
+    missingByColumn: Record<string, number>;
+  };
   /** Min and max date (YYYY-MM-DD) extracted from the parsed rows */
   dateRange?: { minDate: string; maxDate: string };
 }

--- a/frontend/src/features/ModelSetup/utils/__tests__/fwiValues.test.ts
+++ b/frontend/src/features/ModelSetup/utils/__tests__/fwiValues.test.ts
@@ -1,0 +1,91 @@
+/**
+ * FWI value inspection — issue #357.
+ *
+ * The upload step reported "Valid FireSTARR weather file — 264 hourly records
+ * with all required columns including FWI indices" for a file whose indices
+ * were NaN on all but one row per day. It checked that the COLUMNS existed,
+ * never that they held numbers. vita uploaded six times over a week and was
+ * told each time that her file was good.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { analyseFwiValues } from '../weatherValidation.js';
+
+const HEADERS = ['Scenario', 'Date', 'PREC', 'TEMP', 'RH', 'WS', 'WD', 'FFMC', 'DMC', 'DC', 'ISI', 'BUI', 'FWI'];
+
+function row(stamp: string, codes: string[]): string[] {
+  return ['0', stamp, '0', '20', '45', '10', '180', ...codes];
+}
+
+const POPULATED = ['84.65', '20.72', '424.9', '2', '34.44', '4.64'];
+const NAN_TEXT = ['NaN', 'NaN', 'NaN', 'NaN', 'NaN', 'NaN'];
+const EMPTY = ['', '', '', '', '', ''];
+
+describe('analyseFwiValues', () => {
+  it('reports a fully populated file as complete', () => {
+    const report = analyseFwiValues(HEADERS, [
+      row('2026-08-01 00:00:00', POPULATED),
+      row('2026-08-01 01:00:00', POPULATED),
+    ]);
+
+    expect(report!.rowsMissingCodes).toBe(0);
+    expect(report!.rowsWithAllCodes).toBe(2);
+  });
+
+  it('counts rows whose codes are the literal text NaN', () => {
+    const report = analyseFwiValues(HEADERS, [
+      row('2026-08-01 00:00:00', NAN_TEXT),
+      row('2026-08-01 19:00:00', POPULATED),
+      row('2026-08-01 20:00:00', NAN_TEXT),
+    ]);
+
+    expect(report!.totalRows).toBe(3);
+    expect(report!.rowsMissingCodes).toBe(2);
+    expect(report!.rowsWithAllCodes).toBe(1);
+  });
+
+  it('counts empty cells as missing, not as zero', () => {
+    // parseFloat('') is NaN, and a blank FFMC is not an FFMC of 0.
+    const report = analyseFwiValues(HEADERS, [
+      row('2026-08-01 00:00:00', EMPTY),
+      row('2026-08-01 19:00:00', POPULATED),
+    ]);
+
+    expect(report!.rowsMissingCodes).toBe(1);
+  });
+
+  it('names which columns are missing values, and how many', () => {
+    const report = analyseFwiValues(HEADERS, [
+      row('2026-08-01 00:00:00', ['84.65', '', '', '2', '34.44', '4.64']),
+      row('2026-08-01 01:00:00', ['84.65', '', '', '2', '34.44', '4.64']),
+    ]);
+
+    expect(report!.missingByColumn.DMC).toBe(2);
+    expect(report!.missingByColumn.DC).toBe(2);
+    expect(report!.missingByColumn.FFMC).toBe(0);
+  });
+
+  it('treats a row as missing when ANY of the three core codes is absent', () => {
+    // FFMC alone is not a usable set. FireSTARR needs all three.
+    const report = analyseFwiValues(HEADERS, [row('2026-08-01 00:00:00', ['84.65', 'NaN', 'NaN', '2', '34.44', '4.64'])]);
+
+    expect(report!.rowsMissingCodes).toBe(1);
+  });
+
+  it('returns null when the file has no FWI columns at all', () => {
+    // A raw weather file. Nothing to inspect; a different upload tab handles it.
+    const rawHeaders = ['Date', 'PREC', 'TEMP', 'RH', 'WS', 'WD'];
+    expect(analyseFwiValues(rawHeaders, [['2026-08-01 00:00:00', '0', '20', '45', '10', '180']])).toBeNull();
+  });
+
+  it("measures vita's shape: one populated row per day", () => {
+    const rows = [];
+    for (let hour = 0; hour < 24; hour++) {
+      rows.push(row(`2026-08-01 ${String(hour).padStart(2, '0')}:06:00`, hour === 19 ? POPULATED : NAN_TEXT));
+    }
+
+    const report = analyseFwiValues(HEADERS, rows);
+    expect(report!.rowsMissingCodes).toBe(23);
+    expect(report!.rowsWithAllCodes).toBe(1);
+  });
+});

--- a/frontend/src/features/ModelSetup/utils/__tests__/ignitionLatitude.test.ts
+++ b/frontend/src/features/ModelSetup/utils/__tests__/ignitionLatitude.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Ignition latitude resolution — issue #356.
+ *
+ * CFFDRS needs a latitude for its day-length term. App.tsx read it from
+ * geometry.bounds, which is optional, so a polygon ignition drawn without
+ * bounds sent latitude: undefined and failed a network hop later with a
+ * developer-facing message.
+ *
+ * Behaviour is deliberately preserved where it already worked: a Point still
+ * yields its own latitude, and bounds still wins where present, so no existing
+ * model changes its result. Only the undefined case is new.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveIgnitionLatitude } from '../ignitionLatitude.js';
+import type { SpatialData } from '../../types/index.js';
+
+function spatial(overrides: Partial<SpatialData>): SpatialData {
+  return {
+    type: 'polygon',
+    features: [],
+    inputMethod: 'draw',
+    ...overrides,
+  } as SpatialData;
+}
+
+function point(lng: number, lat: number) {
+  return {
+    type: 'Feature' as const,
+    properties: {},
+    geometry: { type: 'Point' as const, coordinates: [lng, lat] },
+  };
+}
+
+function polygon(ring: Array<[number, number]>) {
+  return {
+    type: 'Feature' as const,
+    properties: {},
+    geometry: { type: 'Polygon' as const, coordinates: [ring] },
+  };
+}
+
+function line(coords: Array<[number, number]>) {
+  return {
+    type: 'Feature' as const,
+    properties: {},
+    geometry: { type: 'LineString' as const, coordinates: coords },
+  };
+}
+
+describe('resolveIgnitionLatitude', () => {
+  it('uses the point ignition latitude', () => {
+    const data = spatial({ type: 'point', features: [point(-114.07, 51.05)] as SpatialData['features'] });
+    expect(resolveIgnitionLatitude(data)).toBe(51.05);
+  });
+
+  it('prefers the point over bounds — unchanged from before', () => {
+    const data = spatial({
+      type: 'point',
+      features: [point(-114.07, 51.05)] as SpatialData['features'],
+      bounds: [-120, 44.4, -110, 60],
+    });
+    expect(resolveIgnitionLatitude(data)).toBe(51.05);
+  });
+
+  it('uses bounds minLat for a polygon when bounds are present — unchanged from before', () => {
+    // Preserving this exactly matters: changing it would silently move the
+    // day-length term for every existing polygon model.
+    const data = spatial({
+      features: [polygon([[-114, 60], [-113, 61], [-114, 60]])] as SpatialData['features'],
+      bounds: [-120, 44.4, -110, 62],
+    });
+    expect(resolveIgnitionLatitude(data)).toBe(44.4);
+  });
+
+  describe('when bounds were never populated', () => {
+    it('derives the same minLat from the polygon coordinates', () => {
+      const data = spatial({
+        features: [polygon([[-114, 60.5], [-113, 61.2], [-113.5, 59.8], [-114, 60.5]])] as SpatialData['features'],
+      });
+      expect(resolveIgnitionLatitude(data)).toBe(59.8);
+    });
+
+    it('derives minLat from a linestring', () => {
+      const data = spatial({
+        type: 'line',
+        features: [line([[-114, 62.1], [-113, 60.4]])] as SpatialData['features'],
+      });
+      expect(resolveIgnitionLatitude(data)).toBe(60.4);
+    });
+
+    it('considers every feature, not just the first', () => {
+      const data = spatial({
+        features: [
+          polygon([[-114, 62], [-113, 63], [-114, 62]]),
+          polygon([[-110, 55.25], [-109, 56], [-110, 55.25]]),
+        ] as SpatialData['features'],
+      });
+      expect(resolveIgnitionLatitude(data)).toBe(55.25);
+    });
+  });
+
+  describe('fail-fast', () => {
+    it('throws when there is no geometry at all', () => {
+      expect(() => resolveIgnitionLatitude(spatial({}))).toThrow(/latitude/i);
+    });
+
+    it('names the problem in words a duty officer can act on', () => {
+      // The old failure surfaced as "Latitude required for CFFDRS calculation"
+      // from the backend, after the request had already been sent.
+      expect(() => resolveIgnitionLatitude(spatial({}))).toThrow(/ignition/i);
+    });
+
+    it('throws rather than returning undefined for an empty polygon ring', () => {
+      const data = spatial({ features: [polygon([])] as SpatialData['features'] });
+      expect(() => resolveIgnitionLatitude(data)).toThrow(/latitude/i);
+    });
+  });
+});

--- a/frontend/src/features/ModelSetup/utils/__tests__/weatherPreflight.test.ts
+++ b/frontend/src/features/ModelSetup/utils/__tests__/weatherPreflight.test.ts
@@ -14,6 +14,7 @@ import {
   type StartingCodeCandidate,
 } from '../weatherPreflight.js';
 import type { ModelSetupData } from '../../types/index.js';
+import { resolveZonedInstant } from '../zonedInstant.js';
 
 const CANDIDATE: StartingCodeCandidate = {
   ffmc: 84.65,
@@ -73,14 +74,19 @@ describe('buildIgnitionInstant', () => {
     expect(iso).toMatch(/Z$|[+-]\d{2}:\d{2}$/);
   });
 
-  it('matches what App.tsx sends as timeRange.start, byte for byte', () => {
-    // Deliberate: App.tsx:189 parses this naive string in the BROWSER zone,
-    // which is wrong (#355). The gate reproduces that exactly so the reading
-    // it offers cannot disagree with the run that follows. When #355 is fixed,
-    // both move together and this test is what proves it.
-    const { startDate, startTime } = baseData().temporal;
-    const appTsx = new Date(`${startDate}T${startTime}`).toISOString();
-    expect(buildIgnitionInstant(baseData().temporal)).toBe(appTsx);
+  it('resolves the wall clock in the MODEL timezone, not the browser zone', () => {
+    // 2026-08-04 12:00 in America/Edmonton (MDT, UTC-6) is 18:00Z. Before #355
+    // this depended on where the operator was sitting.
+    expect(buildIgnitionInstant(baseData().temporal)).toBe('2026-08-04T18:00:00.000Z');
+  });
+
+  it('agrees with what App.tsx sends as timeRange.start', () => {
+    // Both now go through resolveZonedInstant, so the codes offered cannot
+    // disagree with the run that follows.
+    const { startDate, startTime, timezone } = baseData().temporal;
+    expect(buildIgnitionInstant(baseData().temporal)).toBe(
+      resolveZonedInstant(startDate, startTime, timezone).toISOString(),
+    );
   });
 });
 

--- a/frontend/src/features/ModelSetup/utils/__tests__/weatherPreflight.test.ts
+++ b/frontend/src/features/ModelSetup/utils/__tests__/weatherPreflight.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Wizard-side pre-flight helpers — issue #351.
+ *
+ * Pure functions only. The wizard calls these around the network round-trip;
+ * keeping them free of React and fetch is what makes the submit gate testable
+ * at all, since no harness exists for that path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildIgnitionInstant,
+  needsPreflight,
+  applyStartingCodes,
+  type StartingCodeCandidate,
+} from '../weatherPreflight.js';
+import type { ModelSetupData } from '../../types/index.js';
+
+const CANDIDATE: StartingCodeCandidate = {
+  ffmc: 84.65,
+  dmc: 20.72,
+  dc: 424.9,
+  observedAt: '2026-08-04T01:06:00.000Z',
+  localLabel: '2026-08-03, 1900',
+};
+
+function csvFile(name = 'station.csv'): File {
+  return new File(['Scenario,Date\n0,2026-08-01 00:06:00'], name, { type: 'text/csv' });
+}
+
+function baseData(overrides: Partial<ModelSetupData> = {}): ModelSetupData {
+  return {
+    geometry: {} as ModelSetupData['geometry'],
+    temporal: {
+      startDate: '2026-08-04',
+      startTime: '12:00',
+      durationHours: 72,
+      timezone: 'America/Edmonton',
+      isForecast: false,
+    },
+    model: {} as ModelSetupData['model'],
+    weather: {
+      source: 'firestarr_csv',
+      firestarrCsvFile: csvFile(),
+      firestarrCsvFileName: 'station.csv',
+    },
+    ...overrides,
+  } as ModelSetupData;
+}
+
+describe('needsPreflight', () => {
+  it('is true for an uploaded FireSTARR CSV — the only shape that can be daily-only', () => {
+    expect(needsPreflight(baseData().weather)).toBe(true);
+  });
+
+  it('is false for raw_weather, which already carries explicit starting codes', () => {
+    expect(needsPreflight({ source: 'raw_weather', rawWeatherFile: csvFile() })).toBe(false);
+  });
+
+  it('is false for spotwx, which is generated rather than uploaded', () => {
+    expect(needsPreflight({ source: 'spotwx', spotwxFile: csvFile() })).toBe(false);
+  });
+
+  it('is false when no file has actually been attached', () => {
+    expect(needsPreflight({ source: 'firestarr_csv' })).toBe(false);
+  });
+});
+
+describe('buildIgnitionInstant', () => {
+  it('produces an ISO string carrying an explicit offset', () => {
+    // The backend rejects bare timestamps that name no offset, so this must
+    // never hand back something like "2026-08-04T12:00".
+    const iso = buildIgnitionInstant(baseData().temporal);
+    expect(iso).toMatch(/Z$|[+-]\d{2}:\d{2}$/);
+  });
+
+  it('matches what App.tsx sends as timeRange.start, byte for byte', () => {
+    // Deliberate: App.tsx:189 parses this naive string in the BROWSER zone,
+    // which is wrong (#355). The gate reproduces that exactly so the reading
+    // it offers cannot disagree with the run that follows. When #355 is fixed,
+    // both move together and this test is what proves it.
+    const { startDate, startTime } = baseData().temporal;
+    const appTsx = new Date(`${startDate}T${startTime}`).toISOString();
+    expect(buildIgnitionInstant(baseData().temporal)).toBe(appTsx);
+  });
+});
+
+describe('applyStartingCodes', () => {
+  it('switches the file to the raw_weather path carrying the recovered codes', () => {
+    const applied = applyStartingCodes(baseData(), CANDIDATE);
+
+    expect(applied.weather.source).toBe('raw_weather');
+    expect(applied.weather.startingCodes).toEqual({ ffmc: 84.65, dmc: 20.72, dc: 424.9 });
+  });
+
+  it('carries the very same file across — the user uploaded it once', () => {
+    const data = baseData();
+    const applied = applyStartingCodes(data, CANDIDATE);
+
+    expect(applied.weather.rawWeatherFile).toBe(data.weather.firestarrCsvFile);
+    expect(applied.weather.rawWeatherFileName).toBe('station.csv');
+  });
+
+  it('clears the firestarr_csv fields so no stale second source is left behind', () => {
+    const applied = applyStartingCodes(baseData(), CANDIDATE);
+
+    expect(applied.weather.firestarrCsvFile).toBeUndefined();
+    expect(applied.weather.firestarrCsvFileName).toBeUndefined();
+  });
+
+  it('does not mutate the wizard state it was handed', () => {
+    const data = baseData();
+    applyStartingCodes(data, CANDIDATE);
+
+    expect(data.weather.source).toBe('firestarr_csv');
+    expect(data.weather.startingCodes).toBeUndefined();
+  });
+
+  it('leaves every other part of the setup untouched', () => {
+    const data = baseData();
+    const applied = applyStartingCodes(data, CANDIDATE);
+
+    expect(applied.temporal).toEqual(data.temporal);
+    expect(applied.geometry).toBe(data.geometry);
+    expect(applied.model).toBe(data.model);
+  });
+});

--- a/frontend/src/features/ModelSetup/utils/__tests__/weatherValidation.test.ts
+++ b/frontend/src/features/ModelSetup/utils/__tests__/weatherValidation.test.ts
@@ -206,6 +206,14 @@ describe('buildParsedWeatherCSV', () => {
       previewRows: rows.slice(0, 5),
       hasScenarioColumn: true,
       hasFWIColumns: true,
+      // #357: the summary now reports what the FWI columns hold, not just that
+      // they exist. These rows are fully populated.
+      fwiValues: {
+        totalRows: 2,
+        rowsWithAllCodes: 2,
+        rowsMissingCodes: 0,
+        missingByColumn: { FFMC: 0, DMC: 0, DC: 0, ISI: 0, BUI: 0, FWI: 0 },
+      },
       dateRange: { minDate: '2025-07-15', maxDate: '2025-07-17' },
     });
   });

--- a/frontend/src/features/ModelSetup/utils/__tests__/zonedInstant.test.ts
+++ b/frontend/src/features/ModelSetup/utils/__tests__/zonedInstant.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Zone-aware instant construction — issue #355.
+ *
+ * The wizard collects a date, a time, and an IANA timezone. Those three must
+ * combine into one instant. Every existing site does `new Date("YYYY-MM-DDTHH:mm")`,
+ * which JavaScript reads in the BROWSER's zone, so the declared timezone is
+ * ignored and the same inputs produce different runs by operator location.
+ *
+ * No date library exists in this package, deliberately — these use Intl, the
+ * same mechanism dateHelpers.ts already relies on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveZonedInstant } from '../zonedInstant.js';
+
+describe('resolveZonedInstant', () => {
+  it('resolves a summer mountain-daylight time to the right instant', () => {
+    // 2026-08-04 12:00 MDT (UTC-6) === 18:00Z. Vita's ignition.
+    const instant = resolveZonedInstant('2026-08-04', '12:00', 'America/Edmonton');
+    expect(instant.toISOString()).toBe('2026-08-04T18:00:00.000Z');
+  });
+
+  it('resolves a winter mountain-standard time, offset and all', () => {
+    // 2026-01-04 12:00 MST (UTC-7) === 19:00Z. The offset differs from summer,
+    // which a fixed offset would get wrong half the year.
+    const instant = resolveZonedInstant('2026-01-04', '12:00', 'America/Edmonton');
+    expect(instant.toISOString()).toBe('2026-01-04T19:00:00.000Z');
+  });
+
+  it('handles a half-hour offset zone', () => {
+    // Newfoundland daylight time is UTC-2:30.
+    const instant = resolveZonedInstant('2026-08-04', '12:00', 'America/St_Johns');
+    expect(instant.toISOString()).toBe('2026-08-04T14:30:00.000Z');
+  });
+
+  it('is the identity for UTC', () => {
+    const instant = resolveZonedInstant('2026-08-04', '12:00', 'UTC');
+    expect(instant.toISOString()).toBe('2026-08-04T12:00:00.000Z');
+  });
+
+  it('resolves an eastern-hemisphere zone', () => {
+    // Tokyo is UTC+9 year round.
+    const instant = resolveZonedInstant('2026-08-04', '12:00', 'Asia/Tokyo');
+    expect(instant.toISOString()).toBe('2026-08-04T03:00:00.000Z');
+  });
+
+  it('produces different instants for the same wall clock in different zones', () => {
+    // The whole point of #355: an Ontario duty officer and an NWT one entering
+    // identical wizard values must get the fire's zone, not their own.
+    const edmonton = resolveZonedInstant('2026-08-04', '12:00', 'America/Edmonton');
+    const toronto = resolveZonedInstant('2026-08-04', '12:00', 'America/Toronto');
+
+    expect(edmonton.getTime()).not.toBe(toronto.getTime());
+    expect(edmonton.getTime() - toronto.getTime()).toBe(2 * 60 * 60 * 1000);
+  });
+
+  it('crosses a DST boundary correctly on the day the clocks go forward', () => {
+    // 2026-03-08 is the US/Canada spring-forward date. 03:00 local is MDT.
+    const instant = resolveZonedInstant('2026-03-08', '03:00', 'America/Edmonton');
+    expect(instant.toISOString()).toBe('2026-03-08T09:00:00.000Z');
+  });
+
+  it('resolves a time on the day the clocks go back', () => {
+    // 2026-11-01, fall-back. 12:00 local is MST (UTC-7) by midday.
+    const instant = resolveZonedInstant('2026-11-01', '12:00', 'America/Edmonton');
+    expect(instant.toISOString()).toBe('2026-11-01T19:00:00.000Z');
+  });
+
+  it('accepts a time with seconds', () => {
+    const instant = resolveZonedInstant('2026-08-04', '12:30:45', 'UTC');
+    expect(instant.toISOString()).toBe('2026-08-04T12:30:45.000Z');
+  });
+
+  it('defaults a missing time to midnight local', () => {
+    const instant = resolveZonedInstant('2026-08-04', '', 'America/Edmonton');
+    expect(instant.toISOString()).toBe('2026-08-04T06:00:00.000Z');
+  });
+
+  describe('fail-fast', () => {
+    it('throws on an unknown timezone rather than silently using the browser zone', () => {
+      expect(() => resolveZonedInstant('2026-08-04', '12:00', 'Mars/Olympus_Mons')).toThrow(/timezone/i);
+    });
+
+    it('throws on a malformed date', () => {
+      expect(() => resolveZonedInstant('not-a-date', '12:00', 'UTC')).toThrow(/date/i);
+    });
+
+    it('throws on a malformed time', () => {
+      expect(() => resolveZonedInstant('2026-08-04', '25:99', 'UTC')).toThrow(/time/i);
+    });
+  });
+});

--- a/frontend/src/features/ModelSetup/utils/ignitionLatitude.ts
+++ b/frontend/src/features/ModelSetup/utils/ignitionLatitude.ts
@@ -1,0 +1,63 @@
+/**
+ * Ignition latitude resolution — issue #356.
+ *
+ * CFFDRS needs a latitude for its day-length term, and the backend treats it as
+ * mandatory on the raw_weather path (WeatherService.ts:106). App.tsx read it
+ * from geometry.bounds, which is optional, so a polygon ignition drawn without
+ * bounds sent `latitude: undefined` and failed a network hop later with a
+ * message written for a developer.
+ *
+ * Resolution order preserves what already worked, so no existing model changes
+ * its result:
+ *
+ *   1. a Point ignition's own latitude
+ *   2. bounds[1] — minLat — where bounds is populated
+ *   3. the minimum latitude across the drawn coordinates, which is what bounds
+ *      would have held
+ *
+ * If none of those yields a number it throws, rather than letting an undefined
+ * required value cross the network.
+ */
+
+import type { SpatialData } from '../types/index.js';
+
+/** Every [lng, lat] pair in a drawn feature, whatever its geometry type. */
+function coordinatesOf(feature: SpatialData['features'][number]): number[][] {
+  const { geometry } = feature;
+
+  if (geometry.type === 'Point') return [geometry.coordinates];
+  if (geometry.type === 'LineString') return geometry.coordinates;
+  if (geometry.type === 'Polygon') return geometry.coordinates.flat();
+
+  return [];
+}
+
+export function resolveIgnitionLatitude(geometry: SpatialData): number {
+  const features = geometry.features ?? [];
+
+  // 1. A point ignition names its own latitude. Unchanged from before.
+  const first = features[0];
+  if (first?.geometry?.type === 'Point') {
+    const latitude = (first.geometry.coordinates as [number, number])[1];
+    if (Number.isFinite(latitude)) return latitude;
+  }
+
+  // 2. bounds is [minLng, minLat, maxLng, maxLat]. Unchanged from before —
+  //    changing it would silently move the day-length term for every existing
+  //    polygon model.
+  const bounded = geometry.bounds?.[1];
+  if (Number.isFinite(bounded)) return bounded as number;
+
+  // 3. Derive what bounds would have held. The coordinates are always there;
+  //    bounds is not.
+  const latitudes = features
+    .flatMap(coordinatesOf)
+    .map((position) => position[1])
+    .filter((latitude): latitude is number => Number.isFinite(latitude));
+
+  if (latitudes.length > 0) return Math.min(...latitudes);
+
+  throw new Error(
+    'Ignition latitude could not be determined — draw or import an ignition before starting the model',
+  );
+}

--- a/frontend/src/features/ModelSetup/utils/weatherPreflight.ts
+++ b/frontend/src/features/ModelSetup/utils/weatherPreflight.ts
@@ -18,6 +18,7 @@
  */
 
 import type { ModelSetupData, TemporalData, WeatherData } from '../types/index.js';
+import { resolveZonedInstant } from './zonedInstant.js';
 
 /** The reading recovered by the backend, as it arrives over JSON. */
 export interface StartingCodeCandidate {
@@ -45,18 +46,15 @@ export function needsPreflight(weather: WeatherData): boolean {
 }
 
 /**
- * The ignition instant, built exactly as App.tsx:189 builds timeRange.start.
+ * The ignition instant, resolved in the MODEL's timezone.
  *
- * That line parses a naive date-time string, which JavaScript reads in the
- * BROWSER's zone rather than the model's declared timezone — filed as #355.
- * This reproduces the bug deliberately: the pre-flight answer depends on which
- * daily reading precedes ignition, so if the gate computed a more correct
- * instant than the run that follows it, the codes offered could disagree with
- * the codes the model actually needed. One consistent error beats two
- * inconsistent ones. When #355 is fixed, both move together.
+ * Previously this deliberately reproduced App.tsx:189's browser-zone bug so the
+ * pre-flight answer could not disagree with the run that followed it. #355 is
+ * now fixed, and both sites moved together — App.tsx and this helper share
+ * resolveZonedInstant, so they cannot drift apart again.
  */
 export function buildIgnitionInstant(temporal: TemporalData): string {
-  return new Date(`${temporal.startDate}T${temporal.startTime}`).toISOString();
+  return resolveZonedInstant(temporal.startDate, temporal.startTime, temporal.timezone).toISOString();
 }
 
 /**

--- a/frontend/src/features/ModelSetup/utils/weatherPreflight.ts
+++ b/frontend/src/features/ModelSetup/utils/weatherPreflight.ts
@@ -1,0 +1,113 @@
+/**
+ * Wizard-side pre-flight helpers — issue #351.
+ *
+ * A FireSTARR-format CSV carrying CFFDRS values on daily rows only satisfies
+ * neither supported weather contract. Uploaded as firestarr_csv it parses to
+ * NaN on every other row, and those NaNs reach the FireSTARR command line and
+ * segfault the engine. The user already has the starting codes — they are in
+ * the file — so we find them and offer them rather than guessing or refusing.
+ *
+ * These live in features/ModelSetup/ on purpose. DashboardContainer and
+ * ModelSetupWizard never call runModel themselves; they forward to a
+ * host-supplied onComplete. App.tsx is only the SAN reference implementation,
+ * so a check built there would protect SAN and leave every ACN integrator with
+ * the same NaN and the same segfault.
+ *
+ * Pure functions only — no React, no fetch. That is what makes the submit gate
+ * testable, since no harness exists for that path.
+ */
+
+import type { ModelSetupData, TemporalData, WeatherData } from '../types/index.js';
+
+/** The reading recovered by the backend, as it arrives over JSON. */
+export interface StartingCodeCandidate {
+  ffmc: number;
+  dmc: number;
+  dc: number;
+  /** ISO instant the reading was taken. */
+  observedAt: string;
+  /** Human-facing local label, e.g. "2026-08-03, 1900". */
+  localLabel: string;
+}
+
+export interface PreflightResult {
+  dailyOnlyCffdrs: boolean;
+  candidate: StartingCodeCandidate | null;
+}
+
+/**
+ * Only an uploaded FireSTARR CSV can have the daily-only shape. raw_weather
+ * already carries explicit starting codes, and spotwx is generated rather than
+ * uploaded, so neither is worth a round-trip.
+ */
+export function needsPreflight(weather: WeatherData): boolean {
+  return weather.source === 'firestarr_csv' && weather.firestarrCsvFile !== undefined;
+}
+
+/**
+ * The ignition instant, built exactly as App.tsx:189 builds timeRange.start.
+ *
+ * That line parses a naive date-time string, which JavaScript reads in the
+ * BROWSER's zone rather than the model's declared timezone — filed as #355.
+ * This reproduces the bug deliberately: the pre-flight answer depends on which
+ * daily reading precedes ignition, so if the gate computed a more correct
+ * instant than the run that follows it, the codes offered could disagree with
+ * the codes the model actually needed. One consistent error beats two
+ * inconsistent ones. When #355 is fixed, both move together.
+ */
+export function buildIgnitionInstant(temporal: TemporalData): string {
+  return new Date(`${temporal.startDate}T${temporal.startTime}`).toISOString();
+}
+
+/**
+ * Rewrites the weather config onto the raw_weather path, carrying the codes
+ * recovered from the user's own file.
+ *
+ * The same File is reused — the user uploaded it once and should not be asked
+ * again. The firestarr_csv fields are cleared so no stale second source is left
+ * for a later step to pick up.
+ *
+ * Returns a new object; the wizard's state is never mutated in place.
+ */
+export function applyStartingCodes(
+  data: ModelSetupData,
+  candidate: StartingCodeCandidate,
+): ModelSetupData {
+  const {
+    firestarrCsvFile,
+    firestarrCsvFileName,
+    firestarrCsvParsed: _dropped,
+    ...rest
+  } = data.weather;
+
+  return {
+    ...data,
+    weather: {
+      ...rest,
+      source: 'raw_weather',
+      rawWeatherFile: firestarrCsvFile,
+      rawWeatherFileName: firestarrCsvFileName,
+      startingCodes: {
+        ffmc: candidate.ffmc,
+        dmc: candidate.dmc,
+        dc: candidate.dc,
+      },
+    },
+  };
+}
+
+/**
+ * Reads an uploaded file to text.
+ *
+ * FileReader rather than File.text(): it is what the rest of the codebase uses
+ * (App.tsx:193-200, and each of the upload components), and File.text() is not
+ * implemented in jsdom, which would leave the submit gate untestable.
+ */
+export function readFileText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () => reject(reader.error ?? new Error(`Could not read ${file.name}`));
+    reader.readAsText(file);
+  });
+}

--- a/frontend/src/features/ModelSetup/utils/weatherValidation.ts
+++ b/frontend/src/features/ModelSetup/utils/weatherValidation.ts
@@ -183,6 +183,7 @@ export function buildParsedWeatherCSV(
   const hasFWIColumns = FWI_COLUMNS.every((col) => headerSet.has(col.toUpperCase()));
   const hasScenarioColumn = headerSet.has('SCENARIO');
   const dateRange = extractDateRange(headers, rows);
+  const fwiValues = analyseFwiValues(headers, rows);
 
   return {
     headers,
@@ -190,6 +191,7 @@ export function buildParsedWeatherCSV(
     previewRows: rows.slice(0, 5),
     hasScenarioColumn,
     hasFWIColumns,
+    ...(fwiValues ? { fwiValues } : {}),
     ...(dateRange ? { dateRange } : {}),
   };
 }
@@ -225,4 +227,68 @@ export function extractDateRange(
     if (d > maxDate) maxDate = d;
   }
   return { minDate, maxDate };
+}
+
+/** The three codes FireSTARR takes from the series. A row without all three is unusable. */
+const CORE_FWI_COLUMNS = ['FFMC', 'DMC', 'DC'];
+
+/** What the FWI columns actually CONTAIN, as opposed to whether they exist. */
+export interface FwiValueReport {
+  totalRows: number;
+  /** Rows carrying all three core codes as real numbers. */
+  rowsWithAllCodes: number;
+  /** Rows missing at least one of the three. */
+  rowsMissingCodes: number;
+  /** Count of absent values per FWI column, keyed by column name. */
+  missingByColumn: Record<string, number>;
+}
+
+/**
+ * Inspects the VALUES in the FWI columns — issue #357.
+ *
+ * hasFWIColumns only asks whether the headers are present. A file can carry
+ * every column and still be unusable: vita's recorded its indices once a day,
+ * so 253 of 264 rows held the text "NaN", and the upload step called it valid.
+ *
+ * Empty cells count as missing rather than as zero — parseFloat('') is NaN, and
+ * a blank FFMC is not an FFMC of nought.
+ *
+ * Returns null when the file has no FWI columns at all; that is a raw weather
+ * file and a different upload tab handles it.
+ */
+export function analyseFwiValues(
+  headers: string[],
+  rows: string[][],
+): FwiValueReport | null {
+  const upper = headers.map((h) => h.trim().toUpperCase());
+  const present = FWI_COLUMNS.filter((col) => upper.includes(col));
+  if (present.length === 0) return null;
+
+  const missingByColumn: Record<string, number> = {};
+  for (const col of present) missingByColumn[col] = 0;
+
+  let rowsWithAllCodes = 0;
+
+  for (const row of rows) {
+    let coreComplete = true;
+
+    for (const col of present) {
+      const value = row[upper.indexOf(col)]?.trim() ?? '';
+      const usable = value !== '' && Number.isFinite(Number(value));
+
+      if (!usable) {
+        missingByColumn[col] += 1;
+        if (CORE_FWI_COLUMNS.includes(col)) coreComplete = false;
+      }
+    }
+
+    if (coreComplete) rowsWithAllCodes += 1;
+  }
+
+  return {
+    totalRows: rows.length,
+    rowsWithAllCodes,
+    rowsMissingCodes: rows.length - rowsWithAllCodes,
+    missingByColumn,
+  };
 }

--- a/frontend/src/features/ModelSetup/utils/zonedInstant.ts
+++ b/frontend/src/features/ModelSetup/utils/zonedInstant.ts
@@ -1,0 +1,102 @@
+/**
+ * Zone-aware instant construction — issue #355.
+ *
+ * The wizard collects a date, a time, and an IANA timezone. Combining them with
+ * `new Date("YYYY-MM-DDTHH:mm")` reads the string in the BROWSER's zone, so the
+ * timezone the user explicitly chose is ignored and the same inputs produce
+ * different instants depending on where the operator happens to be sitting.
+ *
+ * There is no date library in this package and we are not adding one for this.
+ * Intl carries the whole timezone database, and dateHelpers.ts already leans on
+ * it, so the offset is looked up rather than assumed — which also means DST and
+ * half-hour zones fall out correctly instead of needing special cases.
+ */
+
+const DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const TIME_PATTERN = /^(\d{2}):(\d{2})(?::(\d{2}))?$/;
+
+/**
+ * How far the given zone sits from UTC at a particular instant, in ms.
+ *
+ * Works by asking Intl what wall-clock time the zone shows at that instant,
+ * then reading that wall clock back as if it were UTC. The difference is the
+ * offset. hourCycle h23 keeps midnight as 00 rather than 24.
+ */
+function zoneOffsetMs(instant: number, timeZone: string): number {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
+  const parts: Record<string, number> = {};
+  for (const { type, value } of formatter.formatToParts(new Date(instant))) {
+    if (type !== 'literal') parts[type] = Number(value);
+  }
+
+  const wallClockAsUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+
+  return wallClockAsUtc - instant;
+}
+
+/** Rejects an unknown zone rather than letting Intl fall back to the browser's. */
+function assertZone(timeZone: string): void {
+  try {
+    new Intl.DateTimeFormat('en-CA', { timeZone });
+  } catch {
+    throw new Error(`Unknown timezone: ${timeZone}`);
+  }
+}
+
+/**
+ * @param date     YYYY-MM-DD
+ * @param time     HH:mm or HH:mm:ss. Empty means midnight local.
+ * @param timeZone IANA identifier — the model's zone, never the browser's.
+ */
+export function resolveZonedInstant(date: string, time: string, timeZone: string): Date {
+  assertZone(timeZone);
+
+  const dateMatch = DATE_PATTERN.exec(date);
+  if (!dateMatch) {
+    throw new Error(`Invalid date "${date}" — expected YYYY-MM-DD`);
+  }
+
+  const normalisedTime = time.trim() === '' ? '00:00' : time.trim();
+  const timeMatch = TIME_PATTERN.exec(normalisedTime);
+  if (!timeMatch) {
+    throw new Error(`Invalid time "${time}" — expected HH:mm`);
+  }
+
+  const [, year, month, day] = dateMatch.map(Number);
+  const [, hour, minute, second] = timeMatch.map((v) => Number(v ?? 0));
+
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    throw new Error(`Invalid date "${date}"`);
+  }
+  if (hour > 23 || minute > 59 || (second || 0) > 59) {
+    throw new Error(`Invalid time "${time}"`);
+  }
+
+  // Read the wall clock as if it were UTC, then walk back by the zone's offset.
+  const wallClockAsUtc = Date.UTC(year, month - 1, day, hour, minute, second || 0);
+
+  // Two passes. The first offset is looked up at the wrong instant by exactly
+  // the offset itself; re-reading at the corrected instant settles it, which is
+  // what makes DST changeover days land correctly.
+  let instant = wallClockAsUtc - zoneOffsetMs(wallClockAsUtc, timeZone);
+  instant = wallClockAsUtc - zoneOffsetMs(instant, timeZone);
+
+  return new Date(instant);
+}

--- a/frontend/src/services/__tests__/preflightWeather.test.ts
+++ b/frontend/src/services/__tests__/preflightWeather.test.ts
@@ -59,6 +59,53 @@ describe('preflightWeather', () => {
     expect(result.candidate?.localLabel).toBe('2026-08-03, 1900');
   });
 
+  it("carries the server's explanation, not just 'Bad Request' (#339)", async () => {
+    // The backend now returns a message saying exactly what is wrong with the
+    // weather. If ApiError keeps only the HTTP status text, that explanation
+    // never reaches the user — which is the whole complaint in #339.
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      // The REAL shape the backend returns — nested under `error`. Verified
+      // against the running stack; an earlier version of this test invented a
+      // flat body and passed while the fix did not actually work.
+      text: async () =>
+        JSON.stringify({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message:
+              'FireSTARR builds its daily fire weather from the noon (12:00) record of each day, and this day has none: 2026-08-04.',
+            correlationId: '185602c3',
+          },
+        }),
+    });
+
+    await expect(preflightWeather(REQUEST)).rejects.toThrow(/noon \(12:00\) record/);
+  });
+
+  it('also accepts a flat {message} body', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => JSON.stringify({ message: 'flat shape explanation' }),
+    });
+
+    await expect(preflightWeather(REQUEST)).rejects.toThrow(/flat shape explanation/);
+  });
+
+  it('falls back to the status text when the body carries no message', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'upstream exploded',
+    });
+
+    await expect(preflightWeather(REQUEST)).rejects.toThrow(/Internal Server Error/);
+  });
+
   it('surfaces a rejected file as a thrown error rather than a silent pass', async () => {
     // A 400 here means the CSV could not be parsed. Swallowing it would send
     // the user straight into the segfault this check exists to prevent.

--- a/frontend/src/services/__tests__/preflightWeather.test.ts
+++ b/frontend/src/services/__tests__/preflightWeather.test.ts
@@ -1,0 +1,74 @@
+/**
+ * API client for the pre-flight weather check — issue #351.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { preflightWeather } from '../api.js';
+
+const OK_RESPONSE = {
+  dailyOnlyCffdrs: true,
+  candidate: {
+    ffmc: 84.65,
+    dmc: 20.72,
+    dc: 424.9,
+    observedAt: '2026-08-04T01:06:00.000Z',
+    localLabel: '2026-08-03, 1900',
+  },
+};
+
+const REQUEST = {
+  timezone: 'America/Edmonton',
+  timeRange: { start: '2026-08-04T18:00:00.000Z', end: '2026-08-07T18:00:00.000Z' },
+  weather: { source: 'firestarr_csv' as const, firestarrCsvContent: 'Scenario,Date\n0,x' },
+};
+
+describe('preflightWeather', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => OK_RESPONSE });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts to the versioned endpoint', async () => {
+    await preflightWeather(REQUEST);
+
+    const [url, config] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/v1/models/preflight');
+    expect(config.method).toBe('POST');
+  });
+
+  it('sends the weather content in the body', async () => {
+    await preflightWeather(REQUEST);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.weather.firestarrCsvContent).toBe('Scenario,Date\n0,x');
+    expect(body.timezone).toBe('America/Edmonton');
+    expect(body.timeRange.start).toBe('2026-08-04T18:00:00.000Z');
+  });
+
+  it('returns the parsed result', async () => {
+    const result = await preflightWeather(REQUEST);
+
+    expect(result.dailyOnlyCffdrs).toBe(true);
+    expect(result.candidate?.ffmc).toBe(84.65);
+    expect(result.candidate?.localLabel).toBe('2026-08-03, 1900');
+  });
+
+  it('surfaces a rejected file as a thrown error rather than a silent pass', async () => {
+    // A 400 here means the CSV could not be parsed. Swallowing it would send
+    // the user straight into the segfault this check exists to prevent.
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => JSON.stringify({ error: 'Required column "date" not found in CSV' }),
+    });
+
+    await expect(preflightWeather(REQUEST)).rejects.toThrow();
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -374,3 +374,36 @@ export async function updateNotificationPreferences(
     body: JSON.stringify(data),
   });
 }
+
+/**
+ * Pre-flight weather inspection — issue #351.
+ *
+ * Read-only. Detects the daily-only CFFDRS shape and returns the starting codes
+ * already present in the user's file. Creates no model and no job, so declining
+ * the offer leaves nothing behind to clean up.
+ */
+export interface PreflightRequest {
+  timezone: string;
+  timeRange: { start: string; end: string };
+  weather: { source: 'firestarr_csv' | 'raw_weather' | 'spotwx'; firestarrCsvContent?: string };
+}
+
+export interface PreflightCandidate {
+  ffmc: number;
+  dmc: number;
+  dc: number;
+  observedAt: string;
+  localLabel: string;
+}
+
+export interface PreflightResponse {
+  dailyOnlyCffdrs: boolean;
+  candidate: PreflightCandidate | null;
+}
+
+export async function preflightWeather(body: PreflightRequest): Promise<PreflightResponse> {
+  return request<PreflightResponse>('/models/preflight', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -70,8 +70,24 @@ async function request<T>(
     } catch {
       details = text;
     }
+    // Prefer the server's own explanation over the HTTP status text (#339).
+    // The backend now says exactly what is wrong — which noon record is
+    // missing, how to fix it — and "API request failed: Bad Request" would
+    // throw that away and leave the user with the same opacity as before.
+    // The backend nests it as { error: { message } }; some routes return a flat
+    // { message }. Verified against the running stack — reading only the flat
+    // form silently fell back to "Bad Request".
+    const asRecord = (v: unknown): Record<string, unknown> | undefined =>
+      v !== null && typeof v === 'object' ? (v as Record<string, unknown>) : undefined;
+
+    const body = asRecord(details);
+    const nested = asRecord(body?.error);
+    const serverMessage = [nested?.message, body?.message].find(
+      (m): m is string => typeof m === 'string' && m.length > 0,
+    );
+
     throw new ApiError(
-      `API request failed: ${response.statusText}`,
+      serverMessage ?? `API request failed: ${response.statusText}`,
       response.status,
       details
     );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -396,9 +396,17 @@ export interface PreflightCandidate {
   localLabel: string;
 }
 
+export interface PreflightRhythm {
+  dailyHour: number;
+  hoursFromNoon: number;
+  likelyZoneMismatch: boolean;
+}
+
 export interface PreflightResponse {
   dailyOnlyCffdrs: boolean;
   candidate: PreflightCandidate | null;
+  /** How the file's daily rhythm compares with the timezone contract (#354). */
+  rhythm: PreflightRhythm | null;
 }
 
 export async function preflightWeather(body: PreflightRequest): Promise<PreflightResponse> {

--- a/frontend/src/shared/utils/__tests__/recordedFuelVintage.test.ts
+++ b/frontend/src/shared/utils/__tests__/recordedFuelVintage.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Adapting a recorded fuel vintage for display — issue #331.
+ *
+ * The run records the vintage DIRECTORY it used, which is either a year
+ * ("2024") or "default". The display type expects a numeric vintage, so the
+ * two have to be reconciled — without inventing a year for "default".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { recordedToResolved } from '../fuelVintage.js';
+
+describe('recordedToResolved', () => {
+  it('carries a year vintage through as a number', () => {
+    const resolved = recordedToResolved({
+      requestedYear: 2024,
+      vintage: '2024',
+      matchedRequestedYear: true,
+      usedFallback: false,
+    });
+
+    expect(resolved.vintage).toBe(2024);
+    expect(resolved.matchedRequestedYear).toBe(true);
+    expect(resolved.usedFallback).toBe(false);
+    expect(resolved.requestedYear).toBe(2024);
+  });
+
+  it('leaves the vintage undefined for a default dataset rather than inventing a year', () => {
+    const resolved = recordedToResolved({
+      requestedYear: 2024,
+      vintage: 'default',
+      matchedRequestedYear: false,
+      usedFallback: true,
+    });
+
+    expect(resolved.vintage).toBeUndefined();
+    expect(resolved.usedFallback).toBe(true);
+  });
+
+  it('preserves the mismatch when a different year stood in', () => {
+    const resolved = recordedToResolved({
+      requestedYear: 2024,
+      vintage: '2023',
+      matchedRequestedYear: false,
+      usedFallback: true,
+    });
+
+    expect(resolved.vintage).toBe(2023);
+    expect(resolved.matchedRequestedYear).toBe(false);
+  });
+});

--- a/frontend/src/shared/utils/fuelVintage.ts
+++ b/frontend/src/shared/utils/fuelVintage.ts
@@ -98,3 +98,32 @@ export function describeFuelVintage(
     blocking: false,
   };
 }
+
+/** A fuel vintage as recorded by the run that used it (#331). */
+export interface RecordedFuelVintage {
+  requestedYear: number;
+  vintage: string;
+  matchedRequestedYear: boolean;
+  usedFallback: boolean;
+  gridPath?: string;
+  recordedAt?: string;
+}
+
+/**
+ * Adapts a recorded vintage for display — issue #331.
+ *
+ * The run records the vintage DIRECTORY it used, which is a year ("2024") or
+ * "default". The display type carries a numeric vintage, so a non-numeric
+ * directory becomes undefined rather than being coerced into a year that was
+ * never used.
+ */
+export function recordedToResolved(record: RecordedFuelVintage): ResolvedFuelDataset {
+  const numeric = Number(record.vintage);
+
+  return {
+    requestedYear: record.requestedYear,
+    vintage: Number.isInteger(numeric) ? numeric : undefined,
+    matchedRequestedYear: record.matchedRequestedYear,
+    usedFallback: record.usedFallback,
+  };
+}

--- a/scripts/__tests__/update_env_placeholder.test.sh
+++ b/scripts/__tests__/update_env_placeholder.test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Regression test for install_nomad_setup.sh :: update_env_value() — issue #343
+#
+# The installer copies .env.example to .env, and .env.example ships NON-EMPTY
+# placeholders. The #292 fix ("never overwrite an existing non-empty value")
+# then preserved those placeholders over the answers the operator gave at the
+# prompt. 5.5 GB of fuel rasters landed in a literal directory called
+# /absolute/path/to/firestarr_data, and the install reported success.
+#
+# Both behaviours are individually correct. Together they misdirect the install.
+# A placeholder must be treated as ABSENT, while genuine operator values keep
+# the #292 protection exactly as before.
+#
+# Deps: bash, sed, grep only. Exit 0 = all pass, 1 = any failure.
+set -u
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="$TEST_DIR/../install_nomad_setup.sh"
+[ -f "$INSTALLER" ] || { echo "installer not found at $INSTALLER"; exit 1; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Extract the real functions + a minimal harness (stub the printers), then source.
+sed -n '/^is_placeholder_value() {/,/^}/p' "$INSTALLER" > "$tmp/fn.sh"
+sed -n '/^update_env_value() {/,/^}/p' "$INSTALLER" >> "$tmp/fn.sh"
+sed -n '/^assert_no_placeholders_in_env() {/,/^}/p' "$INSTALLER" >> "$tmp/fn.sh"
+cat > "$tmp/harness.sh" <<EOF
+DRY_RUN=false
+ENV_FILE="$tmp/.env"
+print_dry_run(){ :; }
+print_info(){ :; }
+print_warning(){ :; }
+print_success(){ :; }
+print_error(){ :; }
+source "$tmp/fn.sh"
+EOF
+
+run() { bash -c "source '$tmp/harness.sh'; $1"; }
+
+pass=0; fail=0
+expect_line() { # desc, exact-line
+  if grep -qx "$2" "$tmp/.env"; then echo "  ok   - $1"; pass=$((pass+1))
+  else echo "  FAIL - $1 (.env: $(tr '\n' '|' < "$tmp/.env"))"; fail=$((fail+1)); fi
+}
+
+echo "placeholders are treated as absent (#343)"
+
+# 1. THE incident: the dataset path placeholder must not survive.
+printf 'FIRESTARR_DATASET_PATH=/absolute/path/to/firestarr_data\n' > "$tmp/.env"
+run 'update_env_value FIRESTARR_DATASET_PATH /root/firestarr_data'
+expect_line "dataset path placeholder overwritten" "FIRESTARR_DATASET_PATH=/root/firestarr_data"
+
+# 2. Same trap, every OAuth credential.
+printf 'NOMAD_OAUTH_GOOGLE_CLIENT_ID=your-google-client-id\n' > "$tmp/.env"
+run 'update_env_value NOMAD_OAUTH_GOOGLE_CLIENT_ID 1234-real.apps.googleusercontent.com'
+expect_line "your-* placeholder overwritten" "NOMAD_OAUTH_GOOGLE_CLIENT_ID=1234-real.apps.googleusercontent.com"
+
+printf 'NOMAD_OAUTH_MICROSOFT_CLIENT_SECRET=your-microsoft-client-secret\n' > "$tmp/.env"
+run 'update_env_value NOMAD_OAUTH_MICROSOFT_CLIENT_SECRET s3cret-value'
+expect_line "microsoft placeholder overwritten" "NOMAD_OAUTH_MICROSOFT_CLIENT_SECRET=s3cret-value"
+
+# 3. Other common placeholder spellings.
+printf 'NOMAD_DB_PASSWORD=changeme\n' > "$tmp/.env"
+run 'update_env_value NOMAD_DB_PASSWORD hunter2'
+expect_line "changeme overwritten" "NOMAD_DB_PASSWORD=hunter2"
+
+echo
+echo "the #292 protection still holds"
+
+# 4. A genuine operator value must STILL be preserved — this is the whole point
+#    of #292 and must not regress.
+printf 'NOMAD_FRONTEND_HOST_PORT=53000\n' > "$tmp/.env"
+run 'update_env_value NOMAD_FRONTEND_HOST_PORT 3901'
+expect_line "genuine value preserved" "NOMAD_FRONTEND_HOST_PORT=53000"
+
+printf 'FIRESTARR_DATASET_PATH=/srv/nomad/data\n' > "$tmp/.env"
+run 'update_env_value FIRESTARR_DATASET_PATH /root/firestarr_data'
+expect_line "genuine dataset path preserved" "FIRESTARR_DATASET_PATH=/srv/nomad/data"
+
+# 5. Over-matching guard: a real path that merely CONTAINS a placeholder word.
+printf 'FIRESTARR_DATASET_PATH=/home/yourname/firestarr_data\n' > "$tmp/.env"
+run 'update_env_value FIRESTARR_DATASET_PATH /root/firestarr_data'
+expect_line "path containing 'your' is not a placeholder" "FIRESTARR_DATASET_PATH=/home/yourname/firestarr_data"
+
+printf 'NOMAD_AGENCY_ID=changeme-inc\n' > "$tmp/.env"
+run 'update_env_value NOMAD_AGENCY_ID other'
+expect_line "value merely starting with changeme is not a placeholder" "NOMAD_AGENCY_ID=changeme-inc"
+
+# 6. Empty values are still filled, as before.
+printf 'NOMAD_AGENCY_ID=\n' > "$tmp/.env"
+run 'update_env_value NOMAD_AGENCY_ID nwt'
+expect_line "empty value still filled" "NOMAD_AGENCY_ID=nwt"
+
+echo
+echo "the post-install assertion catches anything that slipped through"
+
+expect_status() { # desc, expected-status, command
+  local actual
+  bash -c "source '$tmp/harness.sh'; $3" >/dev/null 2>&1 && actual=0 || actual=$?
+  if [ "$actual" -eq "$2" ]; then echo "  ok   - $1"; pass=$((pass+1))
+  else echo "  FAIL - $1 (status $actual, expected $2)"; fail=$((fail+1)); fi
+}
+
+# A fully configured .env passes.
+printf 'FIRESTARR_DATASET_PATH=/root/firestarr_data
+NOMAD_AGENCY_ID=nwt
+' > "$tmp/.env"
+expect_status "clean .env passes" 0 'assert_no_placeholders_in_env'
+
+# The incident state must fail the install rather than reporting success.
+printf 'FIRESTARR_DATASET_PATH=/absolute/path/to/firestarr_data
+' > "$tmp/.env"
+expect_status "placeholder left behind fails" 1 'assert_no_placeholders_in_env'
+
+# Commented examples are documentation, not configuration.
+printf '# FIRESTARR_DATASET_PATH=/absolute/path/to/firestarr_data
+NOMAD_AGENCY_ID=nwt
+' > "$tmp/.env"
+expect_status "commented placeholder ignored" 0 'assert_no_placeholders_in_env'
+
+echo
+echo "passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/__tests__/update_env_placeholder.test.sh
+++ b/scripts/__tests__/update_env_placeholder.test.sh
@@ -120,6 +120,20 @@ NOMAD_AGENCY_ID=nwt
 ' > "$tmp/.env"
 expect_status "commented placeholder ignored" 0 'assert_no_placeholders_in_env'
 
+# OPTIONAL placeholders must not block the install. Found on sulu against the
+# real .env.example: it ships 14 OAuth placeholders, and blocking on those would
+# fail every install that does not use OAuth — which is most of them.
+printf 'FIRESTARR_DATASET_PATH=/root/firestarr_data\nNOMAD_AUTH_MODE=simple\nNOMAD_OAUTH_GOOGLE_CLIENT_ID=your-google-client-id\n' > "$tmp/.env"
+expect_status "unused OAuth placeholder does not block a non-oauth install" 0 'assert_no_placeholders_in_env'
+
+# ...but they DO block when the install actually depends on them.
+printf 'FIRESTARR_DATASET_PATH=/root/firestarr_data\nNOMAD_AUTH_MODE=oauth\nNOMAD_OAUTH_GOOGLE_CLIENT_ID=your-google-client-id\n' > "$tmp/.env"
+expect_status "OAuth placeholder blocks an oauth install" 1 'assert_no_placeholders_in_env'
+
+# The incident key blocks whatever the auth mode.
+printf 'FIRESTARR_DATASET_PATH=/absolute/path/to/firestarr_data\nNOMAD_AUTH_MODE=simple\n' > "$tmp/.env"
+expect_status "dataset path placeholder blocks whatever the auth mode" 1 'assert_no_placeholders_in_env'
+
 echo
 echo "passed: $pass   failed: $fail"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/install_nomad_setup.sh
+++ b/scripts/install_nomad_setup.sh
@@ -1768,9 +1768,73 @@ check_git_autocrlf() {
 # .env Generation
 # ============================================
 
+assert_no_placeholders_in_env() {
+    # Fail the install if any shipped placeholder survived into .env (#343).
+    #
+    # The original incident reported SUCCESS while pointing the dataset
+    # downloader at /absolute/path/to/firestarr_data. An install that finishes
+    # with a placeholder still in place has not finished; saying so here is
+    # cheaper than 5.5 GB in the wrong directory and an operator who has to read
+    # .env by hand to find out.
+    local offenders=()
+    local line key value
+
+    while IFS= read -r line; do
+        case "$line" in
+            \#*|"") continue ;;
+        esac
+
+        key="${line%%=*}"
+        value="${line#*=}"
+        [ -n "$value" ] || continue
+
+        if is_placeholder_value "$value"; then
+            offenders+=("${key}=${value}")
+        fi
+    done < "$ENV_FILE"
+
+    if [ "${#offenders[@]}" -gt 0 ]; then
+        print_error "Configuration incomplete — these still hold shipped placeholders:"
+        for line in "${offenders[@]}"; do
+            print_error "    $line"
+        done
+        print_error "Set them in $ENV_FILE and re-run. Nothing was left half-configured silently."
+        return 1
+    fi
+
+    return 0
+}
+
+is_placeholder_value() {
+    # True when a value is one of OUR shipped placeholders rather than something
+    # an operator chose (#343).
+    #
+    # .env.example ships non-empty placeholders, and the installer copies it to
+    # .env before writing any key. The #292 rule below ("never overwrite an
+    # existing non-empty value") could not tell the two apart, so it preserved
+    # the placeholder and discarded the answer given at the prompt. 5.5 GB of
+    # fuel rasters landed in a literal /absolute/path/to/firestarr_data.
+    #
+    # Anchored patterns only: a genuine path like /home/yourname/data or an
+    # agency id like changeme-inc must NOT be mistaken for a placeholder.
+    local value="$1"
+
+    case "$value" in
+        /absolute/path/to/*)      return 0 ;;
+        /path/to/*)               return 0 ;;
+        your-*)                   return 0 ;;
+        changeme|CHANGEME)        return 0 ;;
+        yourdomain.com|example.com) return 0 ;;
+        xxx|XXX|TODO|TBD)         return 0 ;;
+    esac
+
+    return 1
+}
+
 update_env_value() {
     local key="$1"
     local value="$2"
+    local existing_value
 
     if [ "$DRY_RUN" = true ]; then
         print_dry_run "Would set $key=$value"
@@ -1780,9 +1844,18 @@ update_env_value() {
     # Preserve an existing, non-empty value — never overwrite a user's .env.
     # (#292 demo lesson: the installer clobbered a manually-set host port on
     # re-run, which broke the Cloudflare tunnel. Set-if-absent only.)
+    #
+    # EXCEPT a placeholder we shipped ourselves (#343): that is not an operator
+    # value, and preserving it silently discards the answer they just gave.
     if grep -qE "^${key}=.+" "$ENV_FILE" 2>/dev/null; then
-        print_info "Keeping existing ${key} (not overwriting)"
-        return 0
+        existing_value="$(grep -m1 -E "^${key}=" "$ENV_FILE" | cut -d= -f2-)"
+
+        if is_placeholder_value "$existing_value"; then
+            print_warning "Replacing placeholder ${key}=${existing_value}"
+        else
+            print_info "Keeping existing ${key} (not overwriting)"
+            return 0
+        fi
     fi
 
     if grep -qE "^${key}=" "$ENV_FILE" 2>/dev/null; then
@@ -2336,6 +2409,19 @@ main() {
 
     # Verification
     verify_installation
+
+    # No shipped placeholder may survive into .env (#343). The original
+    # incident reported success while pointing the downloader at
+    # /absolute/path/to/firestarr_data, so "complete" has to mean configured.
+    if [ "$DRY_RUN" != true ]; then
+        if ! assert_no_placeholders_in_env; then
+            echo ""
+            echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+            print_error "Project Nomad setup did NOT complete"
+            echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+            exit 1
+        fi
+    fi
 
     echo ""
     echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"

--- a/scripts/install_nomad_setup.sh
+++ b/scripts/install_nomad_setup.sh
@@ -1769,15 +1769,23 @@ check_git_autocrlf() {
 # ============================================
 
 assert_no_placeholders_in_env() {
-    # Fail the install if any shipped placeholder survived into .env (#343).
+    # Fail the install if a shipped placeholder that this install DEPENDS ON
+    # survived into .env (#343).
     #
     # The original incident reported SUCCESS while pointing the dataset
     # downloader at /absolute/path/to/firestarr_data. An install that finishes
-    # with a placeholder still in place has not finished; saying so here is
-    # cheaper than 5.5 GB in the wrong directory and an operator who has to read
-    # .env by hand to find out.
-    local offenders=()
-    local line key value
+    # with a placeholder in a key it actually uses has not finished.
+    #
+    # But .env.example ships 14 OAuth placeholders, and OAuth is optional —
+    # inert unless NOMAD_AUTH_MODE=oauth. Blocking on those would fail nearly
+    # every install. Found on sulu against the real .env.example; an earlier
+    # version of this check did exactly that. So placeholders are split:
+    # blocking for keys in use, advisory for keys that are not.
+    local blocking=()
+    local advisory=()
+    local line key value auth_mode
+
+    auth_mode="$(grep -m1 -E "^NOMAD_AUTH_MODE=" "$ENV_FILE" 2>/dev/null | cut -d= -f2- || true)"
 
     while IFS= read -r line; do
         case "$line" in
@@ -1787,15 +1795,30 @@ assert_no_placeholders_in_env() {
         key="${line%%=*}"
         value="${line#*=}"
         [ -n "$value" ] || continue
+        is_placeholder_value "$value" || continue
 
-        if is_placeholder_value "$value"; then
-            offenders+=("${key}=${value}")
-        fi
+        case "$key" in
+            NOMAD_OAUTH_*)
+                # Only matters when the deployment actually authenticates this way.
+                if [ "$auth_mode" = "oauth" ]; then
+                    blocking+=("${key}=${value}")
+                else
+                    advisory+=("${key}=${value}")
+                fi
+                ;;
+            *)
+                blocking+=("${key}=${value}")
+                ;;
+        esac
     done < "$ENV_FILE"
 
-    if [ "${#offenders[@]}" -gt 0 ]; then
-        print_error "Configuration incomplete — these still hold shipped placeholders:"
-        for line in "${offenders[@]}"; do
+    if [ "${#advisory[@]}" -gt 0 ]; then
+        print_info "${#advisory[@]} optional placeholder(s) left unset (OAuth is not in use) — fine to ignore."
+    fi
+
+    if [ "${#blocking[@]}" -gt 0 ]; then
+        print_error "Configuration incomplete — these hold shipped placeholders and this install uses them:"
+        for line in "${blocking[@]}"; do
             print_error "    $line"
         done
         print_error "Set them in $ENV_FILE and re-run. Nothing was left half-configured silently."


### PR DESCRIPTION
Sprint 17 weather and validation work. 62 commits, closing 16 issues.

Everything here started from one user report: vita uploaded a weather file six times over a week on the CIFFC demo and every run died with `exit 139`. Pulling that thread found a family of related defects.

## The original failure

| | |
|---|---|
| **#350** | `validateWeatherData` could not detect NaN — every comparison with NaN is false, so the range checks passed the one value that is certainly invalid |
| **#351** | A CSV recording its CFFDRS indices once a day parsed to NaN on every other row. Nomad now finds the daily reading already in the file and offers it as starting codes at wizard submit |
| **#357** | The upload step called that file *"Valid FireSTARR weather file … including FWI indices"* while the preview showed `NaN` on every row. It now says what was found: *"253 of 264 rows have no FFMC, DMC or DC"* |

## Timezone correctness

Four defects, one root: the model's declared timezone was not the authority for the model's own times.

| | |
|---|---|
| **#352** | DMC/DC rolled over on the **UTC** day boundary — 18:00 the previous local day in Edmonton — and were driven by the evening observation rather than noon. Both codes were biased low |
| **#354** | The CSV `Date` column had no stated contract. It is local time in the model's zone; that is now documented at the point of enforcement and files are measured against it |
| **#355** | The ignition instant was built in the **browser's** zone, so identical wizard inputs produced different runs depending on where the operator sat |
| **#353** | An unresolvable timezone returned `null`, indistinguishable from "this file has no usable reading" |

**#352 changes model output.** Measured on the same box with identical inputs, pre-sprint vs post-sprint: DMC by day three **35.3 → 41.5 (+17.6%)**, DC essentially unchanged. The old values were wrong in a known direction, but they are the values people have been looking at. Worth telling anyone who has briefed off a raw_weather run.

## Failures that told the user nothing

| | |
|---|---|
| **#339 / #340 / #341** | Weather is now checked against FireSTARR's input contract **before** a model, job or sim directory exists, so it is a 400 the user can act on rather than a job that dies where only the container log sees it |
| **#342** | 5,928 issues and 355 KB became 2 issues and 214 characters, with the diagnosis stated: *"daily steps running backwards, so the file is in reverse chronological order"* |
| **#330** | *"No fuel dataset covers this ignition for 2024. Installed fuel datasets: 2023, 2026…"* instead of `Process exited with code 1` |
| **#356** | Latitude could leave the frontend `undefined` for polygon ignitions and fail a network hop later |
| **#331** | The fuel vintage is recorded when the run happens. Installing a fuel year later no longer rewrites what past runs claim; runs predating this read "not recorded" rather than being given today's answer |
| **#343** | The installer preserved shipped `.env.example` placeholders over prompted values — 5.5 GB landed in a literal `/absolute/path/to/firestarr_data`. Placeholders are now treated as absent, and an install cannot report success with one still in a key it uses |
| **#358** | Submission awaited the notification permission prompt; an unanswered prompt hung it forever behind a spinner |

## Verification

Backend **748 tests / 81 files**, frontend **494 / 58**, `tsc --noEmit` clean on both.

Beyond unit tests, this was exercised against real systems:

- The whole recovery path run end to end on the test VPS against a real build
- **#343 reproduced and verified in situ** on the box where it happened, which is still in the failed state
- **#352 measured** by running the same fire through pre-sprint and post-sprint builds on one box
- The **SS005-23 known-good fire** (874-vertex polygon, real 240-row weather) accepted at every duration the wizard offers, 1d through 30d

## Known gaps

- **No fire has completed end to end** with these changes. Both pre-sprint and post-sprint builds fail identically at the same pre-existing environmental point on the boxes available, so this shows *no regression* rather than *proven working*
- **#340 is the least-trusted change here.** Three defects in it were found by Franco rather than by its tests: a trailing partial day rejected, a fabricated duration premise, and a run-end check I invented that is not in #341. It now passes the real fire and still catches all four evidence-backed failure shapes, but its record this sprint is poor
- For CIFFC sim `0282ccb4` the ignition day *did* have a noon record and it still crashed, so #340 catches a subset of that failure mode
- **#359** (flaky usage tests) is open and unresolved — one hazard removed, symptom not proven gone
- **#318** moved to Sprint 18
