### PR TITLE
Fix flaky backend tests: configure a real test timeout (#359)

### DIFF
--- a/backend/src/api/routes/v1/__tests__/usage.test.ts
+++ b/backend/src/api/routes/v1/__tests__/usage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import { usageRouter, isUsageEndpointEnabled, resolveUsageToken } from '../usage.js';
@@ -51,14 +51,17 @@ function makeApp(opts: {
 }
 
 describe('usage endpoint: registration is fail-closed', () => {
-  const original = process.env.NOMAD_USAGE_API_TOKEN;
-
+  // NOMAD_USAGE_API_TOKEN is read straight off process.env by
+  // isUsageEndpointEnabled() and resolveUsageToken(). Mutating it with a bare
+  // `delete` / assignment leaks across test FILES, because Vitest workers share
+  // process.env — which is how this suite came to fail a different test on each
+  // full-suite run (#359). vi.stubEnv is scoped and unwound by the runner even
+  // if a test throws partway, so the mutation cannot escape this block.
   beforeEach(() => {
-    delete process.env.NOMAD_USAGE_API_TOKEN;
+    vi.stubEnv('NOMAD_USAGE_API_TOKEN', '');
   });
   afterEach(() => {
-    if (original === undefined) delete process.env.NOMAD_USAGE_API_TOKEN;
-    else process.env.NOMAD_USAGE_API_TOKEN = original;
+    vi.unstubAllEnvs();
   });
 
   it('is disabled when no token is configured', () => {
@@ -66,17 +69,17 @@ describe('usage endpoint: registration is fail-closed', () => {
   });
 
   it('is enabled only once a token is configured', () => {
-    process.env.NOMAD_USAGE_API_TOKEN = TOKEN;
+    vi.stubEnv('NOMAD_USAGE_API_TOKEN', TOKEN);
     expect(isUsageEndpointEnabled()).toBe(true);
   });
 
   it('rejects a token that is too short to be worth having', () => {
-    process.env.NOMAD_USAGE_API_TOKEN = 'short';
+    vi.stubEnv('NOMAD_USAGE_API_TOKEN', 'short');
     expect(() => resolveUsageToken()).toThrow(/NOMAD_USAGE_API_TOKEN/);
   });
 
   it('rejects a whitespace-only token rather than treating it as set', () => {
-    process.env.NOMAD_USAGE_API_TOKEN = '                                   ';
+    vi.stubEnv('NOMAD_USAGE_API_TOKEN', '                                   ');
     expect(() => resolveUsageToken()).toThrow();
   });
 });

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest configuration — issue #359.
+ *
+ * The suite had no config at all, so it ran on Vitest's default 5-second test
+ * timeout. Several tests here do real work rather than mocking it: writing and
+ * re-reading the JSONL usage log, loading the real v1 router (which runs
+ * migrations), generating FireSTARR inputs. Individually those finish in well
+ * under a second.
+ *
+ * Under a fully parallel run they contend, and whichever one happens to be
+ * slowest at that moment crosses 5s and fails. That is why a DIFFERENT test
+ * failed on each full-suite run, why it never reproduced when those files were
+ * run on their own, and why it looked like shared state — the usage tests do
+ * the most file I/O, so they were the most frequent casualty.
+ *
+ * Reproduced deliberately by running two full suites concurrently, which failed
+ * `modelsPreflight > route registration` with "Test timed out in 5000ms".
+ *
+ * A longer timeout is the correct fix rather than a papered-over one: nothing
+ * here is meant to complete in 5 seconds specifically, and a timeout that
+ * doubles as a performance assertion produces exactly this — failures that
+ * point at the wrong test and teach people to re-run instead of read.
+ */
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Fixes the intermittent test failures tracked in #359.

## What was wrong

There was no vitest config in the repo, so the whole backend suite ran on Vitest's default **5-second** test timeout.

Several tests do real work rather than mocking it — writing and re-reading the JSONL usage log, loading the real v1 router (which runs migrations), generating FireSTARR inputs. Each finishes well under a second on its own. Under a fully parallel run they contend, and whichever is slowest at that moment crosses 5s and fails.

That accounts for every symptom: a *different* test failing on each full-suite run, never reproducing when the suspect files were run alone, and the usage tests appearing to be the culprit — they do the most file I/O, so they were the most frequent casualty.

## Reproduction and verification

Forced the contention by running two full suites concurrently:

```
FAIL  src/api/__tests__/modelsPreflight.test.ts > route registration
      > is reachable through the real v1 router, not just when mounted directly
  → Test timed out in 5000ms.
```

A test unrelated to the usage endpoint, which is the point — it is whichever test loses the race, not a particular one.

Same doubled-load run with this change: **both suites 748/748**.

## Changes

- `backend/vitest.config.ts` — new. `testTimeout` and `hookTimeout` at 30s. Nothing here is meant to complete in 5 seconds specifically, and a timeout doubling as a performance assertion produces failures that point at the wrong test.
- `usage.test.ts` — `process.env.NOMAD_USAGE_API_TOKEN` mutation scoped with `vi.stubEnv` instead of a bare `delete` and reassign. `isUsageEndpointEnabled()` and `resolveUsageToken()` read that variable at call time, so the window between delete and restore was visible to concurrent suites. A real hazard, but **not** the cause — the flake still occurred after this change, which is what prompted looking further.

Backend suite 748 passed, 81 files.
