### PR TITLE
Update demo splash screen with Sprint 17 fixes (#289)

### DIFF
--- a/backend/src/services/splash/assets/default-splash.md
+++ b/backend/src/services/splash/assets/default-splash.md
@@ -5,7 +5,20 @@ title: Welcome to
 ![Nomad](/nomad-logo.png)
 
 ## What's new
-- Fixed downloading fire perimeters and the arrival-time raster from your results
+
+Weather files
+- A file that records its fire weather indices once a day is no longer rejected — Nomad finds the noon reading already in it and offers those as your starting codes
+- Uploads now tell you when FWI values are missing, instead of reporting the file as valid
+- Weather problems are explained before a model starts, naming the day and what to change, rather than failing part-way through with an exit code
+
+Times and dates
+- Ignition time now uses the timezone you chose for the model, not the timezone of the computer you happen to be sitting at
+- Daily DMC and DC are calculated from local noon conditions, as CFFDRS intends. Results will differ slightly from earlier runs, and are more accurate
+
+Results and setup
+- A missing fuel dataset now names the year it needs and lists the years installed
+- Results record the fuel vintage a model actually used, so installing a dataset later never changes what a past run reports
+- Starting a model no longer waits on the browser's notification prompt
 
 ## Public demo notes
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad/frontend",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Project Nomad - Fire Modeling GUI",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Replaces the splash "What's new" section, which still listed a single item from an earlier sprint.

Rewritten in user-facing terms, grouped by what it affects — weather files, times and dates, results and setup. No issue numbers or internal terminology.

Calls out explicitly that DMC and DC are now calculated from local noon conditions and that results will differ slightly from earlier runs. Someone comparing a fresh run against an older one should not have to work out why on their own.

The demo serves the bundled default (no `NOMAD_SPLASH_PATH` configured), so this file is what nomad.ciffc.ca will show.

Splash tests: 17 passed, 4 files.